### PR TITLE
Single precision extension to the SVE generator

### DIFF
--- a/codegen/architectures/arm_sve/inlineprinter.py
+++ b/codegen/architectures/arm_sve/inlineprinter.py
@@ -19,8 +19,6 @@ class InlinePrinter(Visitor):
         self.output = []
         self.stack = []
         self.precision = precision
-        # TODO: delete assertion when including single precision
-        assert precision == Precision.DOUBLE
 
     def show(self):
         print("\n".join(self.output))

--- a/matmul.py
+++ b/matmul.py
@@ -215,7 +215,7 @@ class MatMul:
                     for ic in range(regs.shape[1]):
                         for ir in range(regs.shape[0]):
                             pred_m = None if not self.is_sve else self.generator.pred_n_trues(self.bm - ir * self.v_size, self.v_size, "m")
-                            asm.add(mul(regs[ir,ic], self.beta_reg[1], regs[ir,ic], pred=pred_m))
+                            asm.add(mul(regs[ir,ic], self.beta_reg[1], regs[ir,ic], "C = beta * C", pred=pred_m))
             else:
                 asm.add(self.generator.make_zero_block(regs, self.additional_regs))
 

--- a/scripts/max_arm_sve.py
+++ b/scripts/max_arm_sve.py
@@ -4,7 +4,7 @@ def getBlocksize(m, n, bk, v_size=2):
     bn = 1
     maxval = 0
 
-    for i in range(2, m + 1, 1):
+    for i in range(1, m + 1, 1):
         next_multiple = i
         while next_multiple % v_size != 0:
             next_multiple += 1

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,4 +1,5 @@
 CXX=g++
+CXXCLANG=clang++
 
 CXXFLAGS=-std=c++17 -O3 -mcpu=native -msve-vector-bits=512 -fopenmp -Wall -g
 CXXFLAGSNEON=-std=c++17 -O3 -mcpu=native -fopenmp -Wall -g
@@ -6,10 +7,10 @@ CXXFLAGSNEON=-std=c++17 -O3 -mcpu=native -fopenmp -Wall -g
 all: sve_testsuite neon_testsuite
 
 sve_testsuite: sve_testsuite.cpp
-	${CXX} ${CXXFLAGS} $< -o sve_testsuite
+    ${CXXCLANG} ${CXXFLAGS} $< -o sve_testsuite
 
 neon_testsuite: testsuite.cpp
-	${CXX} ${CXXFLAGSNEON} $< -o neon_testsuite
+    ${CXX} ${CXXFLAGSNEON} $< -o neon_testsuite
 
 clean:
 	rm -f sve_testsuite

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -7,10 +7,10 @@ CXXFLAGSNEON=-std=c++17 -O3 -mcpu=native -fopenmp -Wall -g
 all: sve_testsuite neon_testsuite
 
 sve_testsuite: sve_testsuite.cpp
-		${CXXCLANG} ${CXXFLAGS} $< -o sve_testsuite
+	${CXXCLANG} ${CXXFLAGS} $< -o sve_testsuite
 
 neon_testsuite: testsuite.cpp
-		${CXX} ${CXXFLAGSNEON} $< -o neon_testsuite
+	${CXX} ${CXXFLAGSNEON} $< -o neon_testsuite
 
 clean:
 	rm -f sve_testsuite

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,16 +1,16 @@
 CXX=g++
 CXXCLANG=clang++
 
-CXXFLAGS=-std=c++17 -O3 -mcpu=native -msve-vector-bits=512 -fopenmp -Wall -g
+CXXFLAGS=-std=c++17 -O3 -mcpu=native -fopenmp -Wall -g
 CXXFLAGSNEON=-std=c++17 -O3 -mcpu=native -fopenmp -Wall -g
 
 all: sve_testsuite neon_testsuite
 
 sve_testsuite: sve_testsuite.cpp
-    ${CXXCLANG} ${CXXFLAGS} $< -o sve_testsuite
+        ${CXXCLANG} ${CXXFLAGS} $< -o sve_testsuite
 
 neon_testsuite: testsuite.cpp
-    ${CXX} ${CXXFLAGSNEON} $< -o neon_testsuite
+        ${CXX} ${CXXFLAGSNEON} $< -o neon_testsuite
 
 clean:
 	rm -f sve_testsuite

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -7,10 +7,10 @@ CXXFLAGSNEON=-std=c++17 -O3 -mcpu=native -fopenmp -Wall -g
 all: sve_testsuite neon_testsuite
 
 sve_testsuite: sve_testsuite.cpp
-        ${CXXCLANG} ${CXXFLAGS} $< -o sve_testsuite
+		${CXXCLANG} ${CXXFLAGS} $< -o sve_testsuite
 
 neon_testsuite: testsuite.cpp
-        ${CXX} ${CXXFLAGSNEON} $< -o neon_testsuite
+		${CXX} ${CXXFLAGSNEON} $< -o neon_testsuite
 
 clean:
 	rm -f sve_testsuite

--- a/tests/README.md
+++ b/tests/README.md
@@ -7,7 +7,19 @@ To fix this, the generated testsuite for Arm NEON and SVE saves certain values a
 instead of passing them as constant values.
 ## Compiling with gcc
 A Makefile is provided, however only NEON and SVE related unit tests can be compiled at the moment. 
-Naturally, other compiler flags than the ones provided may be used.
+Naturally, other compiler flags than the ones provided may be used.  
+Compiling the SVE testsuite with gcc 11.0.0 seems to break some test cases. Within the provided test setup, the values of certain parameters are overwritten after
+specific tests, namely ```sve_arm_only_test15_23_6.h``` and ```sve_arm_only_test16_23_6.h```. This leads to a wrong reference solution which is then compared to 
+the one calculated by our generated kernel.  
+Example output when using GDB:
+```
+Program received signal SIGSEGV, Segmentation fault.
+#0  0x0000000000213dc4 in post<double> (M=7, M@entry=23, N=N@entry=29, K=K@entry=31, LDA=7, LDA@entry=23, LDB=0x3feeb851eb851eb8, LDB@entry=0xffffffffa5ec, LDC=7, LDC@entry=23, A=A@entry=0x2fa8c0, 
+    B=B@entry=0x2fbf40, C=C@entry=0x300cc0, Cref=Cref@entry=0x2ff7c0, DELTA=DELTA@entry=9.9999999999999995e-08, BETA=<optimized out>, ALPHA=<optimized out>, BETA=<optimized out>, 
+    ALPHA=<optimized out>) at sve_testsuite.cpp:179
+#1  0x00000000002aecf4 in main () at sve_testsuite.cpp:619
+```
+Additional testing of gcc-based compilation is needed. Meanwhile, the SVE testsuite should be compiled with clang.
 ## Unit Tests
 Unit tests for all 3 architectures (KNL, Arm NEON, Arm SVE) are provided. 
 The testsuite that corresponds to a unit test needs to be executed on the respective processor/architecture. 

--- a/tests/sve_testsuite_generator.py
+++ b/tests/sve_testsuite_generator.py
@@ -12,108 +12,6 @@ DenseKernel = namedtuple('DenseKernel', 'name m n k lda ldb ldc alpha beta block
 SparseKernelS = namedtuple('SparseKernelS', 'name m n k lda ldb ldc alpha beta block_sizes mtx delta')
 DenseKernelS = namedtuple('DenseKernelS', 'name m n k lda ldb ldc alpha beta block_sizes delta')
 
-# include function definitions for single precision case
-single_precision_function_definitions = """
-void fgemm_ref(unsigned M, unsigned N, unsigned K, unsigned LDA, unsigned LDB, unsigned LDC, float ALPHA, float BETA, float* A, float* B, float* C) {
-  for (unsigned col = 0; col < N; ++col) {
-    for (unsigned row = 0; row < M; ++row) {
-      C[row + col * LDC] = BETA * C[row + col * LDC];
-    }
-  }
-  for (unsigned col = 0; col < N; ++col) {
-    for (unsigned row = 0; row < M; ++row) {
-      for (unsigned s = 0; s < K; ++s) {
-        C[row + col * LDC] += ALPHA * A[row + s * LDA] * B[s + col * LDB];
-      }
-    }
-  }
-}
-
-std::tuple<float*, float*, float*, float*, float*> fpre(unsigned M, unsigned N, unsigned K, unsigned LDA, unsigned LDB, unsigned LDC, std::string MTX) {
-
-  if(LDB == 0)
-    LDB = K;
-
-  float *A;
-  float *B;
-  float *Bsparse;
-  float *Cref;
-  float *C;
-
-  int resA = posix_memalign(reinterpret_cast<void **>(&A), 64, LDA*LDB*sizeof(float));
-  int resB = posix_memalign(reinterpret_cast<void **>(&B), 64, LDB*N*sizeof(float));
-  int resBsparse = posix_memalign(reinterpret_cast<void **>(&Bsparse), 64, LDB*N*sizeof(float));  
-  int resCref = posix_memalign(reinterpret_cast<void **>(&Cref), 64, LDC*N*sizeof(float));
-  int resC = posix_memalign(reinterpret_cast<void **>(&C), 64, LDC*N*sizeof(float));
-
-  std::string line;
-  std::ifstream f(MTX);
-  getline(f, line);
-  getline(f, line);
-  getline(f, line);
-
-  for(int i = 0; i < LDA*LDB; i++)
-    A[i] = (float)rand() / RAND_MAX;
-
-  for(int i = 0; i < LDB*N; i++)
-    if(MTX.compare(""))
-      B[i] = 0;
-    else 
-      B[i] = (float)rand() / RAND_MAX;
-
-  for(int i = 0; i < LDC*N; i++)
-  {
-    Cref[i] = (float)rand() / RAND_MAX;
-    C[i] = Cref[i];
-  }
-
-  if(MTX.compare(""))
-  {
-    while(getline(f, line)) {
-      std::vector<std::string> result;
-      std::istringstream iss(line);
-      for(std::string s; iss >> s; )
-        result.push_back(s);
-      if(std::atoi(result[0].c_str()) <= K && std::atoi(result[1].c_str()) <= N)
-        B[std::atoi(result[0].c_str()) - 1 + LDB * (std::atoi(result[1].c_str()) - 1)] = std::stod(result[2]);
-    }
-  }
-
-  int counter = 0;
-
-  for(int i = 0; i < N; i++)
-  {
-    for(int j = 0; j < K; j++)
-    {
-      if(B[j + i * LDB] != 0 || !MTX.compare(""))
-      {
-        Bsparse[counter] = B[j + i * LDB];
-        counter++;
-      }
-    }
-  }
-
-  f.close();
-
-  return std::make_tuple(A, B, Bsparse, C, Cref);
-}
-
-int fpost(unsigned M, unsigned N, unsigned K, unsigned LDA, unsigned LDB, unsigned LDC, float ALPHA, float BETA, float* A, float* B, float* C, float* Cref, float DELTA) {
-
-  if(LDB == 0)
-    LDB = K;
-
-  fgemm_ref(M, N, K, LDA, LDB, LDC, ALPHA, BETA, A, B, Cref);
-        
-  for(int i = 0; i < M; i++)
-    for(int j = 0; j < N; j++)
-      if(std::abs(C[i + j * LDC] - Cref[i + j * LDC]) > DELTA)
-        return 0;
-
-  return 1;
-}
-
-"""
 def generateMTX(k, n, nnz):
     return test_generator.generateMTX(k, n, nnz)
 
@@ -121,6 +19,8 @@ def make(kernels, arch):
     f = open('sve_testsuite.cpp', 'w')
 
     f.write(test_generator.head_of_testsuite)
+
+    include_single_prec = False
 
     for kern in kernels:
         arguments = [sys.executable, './../pspamm.py', str(kern.m), str(kern.n), str(kern.k), str(kern.lda),
@@ -131,6 +31,8 @@ def make(kernels, arch):
 
         prec = 's' if isinstance(kern, SparseKernelS) or isinstance(kern, DenseKernelS) else 'd'
         arguments += ['--precision', prec]
+        if prec == 's':
+            include_single_prec = True
 
         block_sizes = list(set(kern.block_sizes))
 
@@ -144,7 +46,9 @@ def make(kernels, arch):
                 assert (bm % 2 == 0 and (bn + 1) * (bm / 2) + bn <= 32)
             elif arch == "arm_sve":
                 # this is for A64fx only, with SVE_vector_bits = 512
-                assert ((bn + 1) * (bm / 8) + bn <= 32)
+                v_len = 8 if prec == 'd' else 16
+                # this should be the same assertion as in ../scripts/max_arm_sve.py
+                assert ((bn + 1) * (bm / v_len) + bn <= 32)
 
             name = kern.name + '_' + str(bm) + '_' + str(bn)
 
@@ -160,10 +64,14 @@ def make(kernels, arch):
             f.write('#include "' + arch + '/' + kern.name + '_' + str(bm) + '_' + str(bn) + '.h"\n')
 
     f.write('\n')
-
-    f.write(single_precision_function_definitions)
-
+    # necessary functions are defined in testsuite_generator.py
     f.write(test_generator.function_definitions)
+    # add variable declarations for single precision test cases
+    if include_single_prec:
+        f.write("""
+    std::tuple<float*, float*, float*, float*, float*> fpointers;
+    float falpha; float fbeta;
+    """)
 
     for kern in kernels:
 
@@ -182,13 +90,13 @@ def make(kernels, arch):
             prec = 'f' if isinstance(kern, SparseKernelS) or isinstance(kern, DenseKernelS) else ''
 
             f.write("""
-  ldb = {ldb}; alpha = {alpha}; beta = {beta};
-  {p}pointers = {p}pre({m}, {n}, {k}, {lda}, ldb, {ldc}, "{mtx}");
+  ldb = {ldb}; {p}alpha = {alpha}; {p}beta = {beta};
+  {p}pointers = pre<{T}>({m}, {n}, {k}, {lda}, ldb, {ldc}, "{mtx}");
   {name}(std::get<0>({p}pointers), std::get<{sparse}>({p}pointers), std::get<3>({p}pointers), alpha, beta, nullptr);
-  result = {p}post({m}, {n}, {k}, {lda}, &ldb, {ldc}, &alpha, &beta, std::get<0>({p}pointers), std::get<1>({p}pointers), std::get<3>({p}pointers), std::get<4>({p}pointers), {delta:.7f});
+  result = post<{T}>({m}, {n}, {k}, {lda}, &ldb, {ldc}, &alpha, &beta, std::get<0>({p}pointers), std::get<1>({p}pointers), std::get<3>({p}pointers), std::get<4>({p}pointers), {delta:.7f});
   results.push_back(std::make_tuple("{name}", result));
   free(std::get<0>({p}pointers)); free(std::get<1>({p}pointers)); free(std::get<2>({p}pointers)); free(std::get<3>({p}pointers)); free(std::get<4>({p}pointers));
 """.format(m=kern.m, n=kern.n, k=kern.k, lda=kern.lda, ldb=kern.ldb, ldc=kern.ldc, alpha=kern.alpha, beta=kern.beta,
-           mtx=mtx, delta=kern.delta, name=name, sparse=2 if kern.ldb == 0 else 1, p=prec))
+           mtx=mtx, delta=kern.delta, name=name, sparse=2 if kern.ldb == 0 else 1, p=prec, T="float" if prec == 'f' else "double"))
 
     f.write(test_generator.end_of_testsuite)

--- a/tests/testsuite_generator.py
+++ b/tests/testsuite_generator.py
@@ -129,11 +129,8 @@ int post(unsigned M, unsigned N, unsigned K, unsigned LDA, unsigned* LDB, unsign
     for(int j = 0; j < N; j++)
       // we use the relative error instead of the absolute error because of an issue we found for sparse single precision 
       // kernels presumably due to limited precision of floats
-      if(std::abs((C[i + j * LDC] - Cref[i + j * LDC])) / Cref[i + j * LDC] > DELTA) {
-        // printf("error %.9f > %.9f\\n", std::abs((C[i + j * LDC] - Cref[i + j * LDC])) / Cref[i + j * LDC], DELTA);
+      if(std::abs((C[i + j * LDC] - Cref[i + j * LDC])) / Cref[i + j * LDC] > DELTA)
         return 0;
-      }
-
 
   return 1;
 }

--- a/tests/testsuite_generator.py
+++ b/tests/testsuite_generator.py
@@ -21,7 +21,18 @@ long long pspamm_num_total_flops = 0;
 """
 
 function_definitions = """
-void gemm_ref(unsigned M, unsigned N, unsigned K, unsigned LDA, unsigned LDB, unsigned LDC, double ALPHA, double BETA, double* A, double* B, double* C) {
+template <typename T>
+void pretty_print(unsigned M, unsigned N, unsigned LDC, T* C) {
+  for (int m = 0; m < M; ++m) {
+    for (int n = 0; n < N; ++n) {
+      printf("%.4f ", C[m * LDC + n]);
+    }
+    printf("\\n");
+  }
+}
+
+template <typename T>
+void gemm_ref(unsigned M, unsigned N, unsigned K, unsigned LDA, unsigned LDB, unsigned LDC, T ALPHA, T BETA, T* A, T* B, T* C) {
   for (unsigned col = 0; col < N; ++col) {
     for (unsigned row = 0; row < M; ++row) {
       C[row + col * LDC] = BETA * C[row + col * LDC];
@@ -36,22 +47,23 @@ void gemm_ref(unsigned M, unsigned N, unsigned K, unsigned LDA, unsigned LDB, un
   }
 }
 
-std::tuple<double*, double*, double*, double*, double*> pre(unsigned M, unsigned N, unsigned K, unsigned LDA, unsigned LDB, unsigned LDC, std::string MTX) {
+template <typename T>
+std::tuple<T*, T*, T*, T*, T*> pre(unsigned M, unsigned N, unsigned K, unsigned LDA, unsigned LDB, unsigned LDC, std::string MTX) {
 
   if(LDB == 0)
     LDB = K;
 
-  double *A;
-  double *B;
-  double *Bsparse;
-  double *Cref;
-  double *C;
+  T *A;
+  T *B;
+  T *Bsparse;
+  T *Cref;
+  T *C;
 
-  int resA = posix_memalign(reinterpret_cast<void **>(&A), 64, LDA*LDB*sizeof(double));
-  int resB = posix_memalign(reinterpret_cast<void **>(&B), 64, LDB*N*sizeof(double));
-  int resBsparse = posix_memalign(reinterpret_cast<void **>(&Bsparse), 64, LDB*N*sizeof(double));  
-  int resCref = posix_memalign(reinterpret_cast<void **>(&Cref), 64, LDC*N*sizeof(double));
-  int resC = posix_memalign(reinterpret_cast<void **>(&C), 64, LDC*N*sizeof(double));
+  int resA = posix_memalign(reinterpret_cast<void **>(&A), 64, LDA*LDB*sizeof(T));
+  int resB = posix_memalign(reinterpret_cast<void **>(&B), 64, LDB*N*sizeof(T));
+  int resBsparse = posix_memalign(reinterpret_cast<void **>(&Bsparse), 64, LDB*N*sizeof(T));  
+  int resCref = posix_memalign(reinterpret_cast<void **>(&Cref), 64, LDC*N*sizeof(T));
+  int resC = posix_memalign(reinterpret_cast<void **>(&C), 64, LDC*N*sizeof(T));
 
   std::string line;
   std::ifstream f(MTX);
@@ -60,17 +72,17 @@ std::tuple<double*, double*, double*, double*, double*> pre(unsigned M, unsigned
   getline(f, line);
 
   for(int i = 0; i < LDA*LDB; i++)
-    A[i] = (double)rand() / RAND_MAX;
+    A[i] = (T)rand() / RAND_MAX;
 
   for(int i = 0; i < LDB*N; i++)
     if(MTX.compare(""))
       B[i] = 0;
     else 
-      B[i] = (double)rand() / RAND_MAX;
+      B[i] = (T)rand() / RAND_MAX;
 
   for(int i = 0; i < LDC*N; i++)
   {
-    Cref[i] = (double)rand() / RAND_MAX;
+    Cref[i] = (T)rand() / RAND_MAX;
     C[i] = Cref[i];
   }
 
@@ -105,7 +117,8 @@ std::tuple<double*, double*, double*, double*, double*> pre(unsigned M, unsigned
   return std::make_tuple(A, B, Bsparse, C, Cref);
 }
 
-int post(unsigned M, unsigned N, unsigned K, unsigned LDA, unsigned* LDB, unsigned LDC, double* ALPHA, double* BETA, double* A, double* B, double* C, double* Cref, double DELTA) {
+template <typename T>
+int post(unsigned M, unsigned N, unsigned K, unsigned LDA, unsigned* LDB, unsigned LDC, T* ALPHA, T* BETA, T* A, T* B, T* C, T* Cref, T DELTA) {
 
   if(*LDB == 0)
     *LDB = K;
@@ -114,8 +127,13 @@ int post(unsigned M, unsigned N, unsigned K, unsigned LDA, unsigned* LDB, unsign
     
   for(int i = 0; i < M; i++)
     for(int j = 0; j < N; j++)
-      if(std::abs(C[i + j * LDC] - Cref[i + j * LDC]) > DELTA)
+      // we use the relative error instead of the absolute error because of an issue we found for sparse single precision 
+      // kernels presumably due to limited precision of floats
+      if(std::abs((C[i + j * LDC] - Cref[i + j * LDC])) / Cref[i + j * LDC] > DELTA) {
+        // printf("error %.9f > %.9f\\n", std::abs((C[i + j * LDC] - Cref[i + j * LDC])) / Cref[i + j * LDC], DELTA);
         return 0;
+      }
+
 
   return 1;
 }
@@ -134,9 +152,9 @@ int main()
 
 setup_single_testcase = """
   ldb = {ldb}; alpha = {alpha}; beta = {beta};
-  pointers = pre({m}, {n}, {k}, {lda}, ldb, {ldc}, "{mtx}");
+  pointers = pre<double>({m}, {n}, {k}, {lda}, ldb, {ldc}, "{mtx}");
   {name}(std::get<0>(pointers), std::get<{sparse}>(pointers), std::get<3>(pointers), {alpha}, {beta}, nullptr);
-  result = post({m}, {n}, {k}, {lda}, &ldb, {ldc}, &alpha, &beta, std::get<0>(pointers), std::get<1>(pointers), std::get<3>(pointers), std::get<4>(pointers), {delta:.7f});
+  result = post<double>({m}, {n}, {k}, {lda}, &ldb, {ldc}, &alpha, &beta, std::get<0>(pointers), std::get<1>(pointers), std::get<3>(pointers), std::get<4>(pointers), {delta:.7f});
   results.push_back(std::make_tuple("{name}", result));
   free(std::get<0>(pointers)); free(std::get<1>(pointers)); free(std::get<2>(pointers)); free(std::get<3>(pointers)); free(std::get<4>(pointers));
 """

--- a/tests/unit_tests_arm_sve.py
+++ b/tests/unit_tests_arm_sve.py
@@ -44,7 +44,7 @@ kernels.append(generator.DenseKernel("sve_arm_only_test12", 2, 1, 1, 2, 1, 8, 1.
 kernels.append(generator.DenseKernel("sve_arm_only_test13", 2, 3, 3, 2, 3, 2, 1.0, 0.0, [(2, 1)] + [x.getBlocksize(2, 3, 1, v_size) for x in blocksize_algs], delta_dp))
 kernels.append(generator.DenseKernel("sve_arm_only_test14", 16, 5, 7, 16, 7, 16, 1.0, 1.0, [(8, 1), (8,2)] + [x.getBlocksize(16, 5, 1, v_size) for x in blocksize_algs], delta_dp))
 
-kernels.append(generator.DenseKernel("sve_arm_only_test15", 23, 29, 31, 23, 31, 23, 1.32, 0.96, [x.getBlocksize(23, 29, 1, v_size) for x in blocksize_algs], 0.0000001))
+kernels.append(generator.DenseKernel("sve_arm_only_test15", 23, 29, 31, 23, 31, 23, 1.32, 0.96, [x.getBlocksize(23, 29, 1, v_size) for x in blocksize_algs], delta_dp))
 kernels.append(generator.SparseKernel("sve_arm_only_test16", 23, 29, 31, 23, 0, 23, 1.32, 0.96, [x.getBlocksize(23, 29, 1, v_size) for x in blocksize_algs], generator.generateMTX(31, 29, 61), delta_dp))
 
 # test cases for single precision multiplication

--- a/tests/unit_tests_arm_sve.py
+++ b/tests/unit_tests_arm_sve.py
@@ -9,40 +9,51 @@ v_size = 8
 v_size_s = 16
 kernels = []
 
-kernels.append(generator.DenseKernel("sve_mixed_test1", 9, 9, 9, 9, 9, 9, 1.0, 0.0, [(3, 3)] + [x.getBlocksize(9, 9, 1, v_size) for x in blocksize_algs], 0.0000001))
-kernels.append(generator.SparseKernel("sve_mixed_test2", 9, 9, 9, 9, 0, 9, 4.0, 2.5, [(3, 3)] + [x.getBlocksize(9, 9, 1, v_size) for x in blocksize_algs], generator.generateMTX(9, 9, 20), 0.0000001))
-kernels.append(generator.SparseKernel("sve_mixed_test3", 18, 18, 18, 18, 0, 18, 3.4, -2.5, [(1, 1), (3, 3), (6, 6), (9, 9)] + [x.getBlocksize(18, 18, 1, v_size) for x in blocksize_algs], generator.generateMTX(18, 18, 59), 0.0000001))
-kernels.append(generator.SparseKernel("sve_mixed_test4", 80, 80, 80, 80, 0, 80, 0.0, -2.5, [(4, 4), (8, 8)] + [x.getBlocksize(80, 80, 1, v_size) for x in blocksize_algs], generator.generateMTX(80, 80, 312), 0.0000001))
-kernels.append(generator.SparseKernel("sve_mixed_test5", 8, 8, 8, 10, 0, 8, 3.0, -0.9, [(2, 2), (4, 4)] + [x.getBlocksize(8, 8, 1, v_size) for x in blocksize_algs], generator.generateMTX(8, 8, 6), 0.0000001))
-kernels.append(generator.DenseKernel("sve_mixed_test6", 8, 8, 8, 10, 8, 8, 3.0, -0.9, [(2, 2), (4, 4)] + [x.getBlocksize(8, 8, 1, v_size) for x in blocksize_algs], 0.0000001))
+# define the maximum allowed difference between elements of our solution and the reference solution for
+# double and single precision
+delta_sp = 1e-6
+delta_dp = 1e-7
 
-kernels.append(generator.DenseKernel("sve_test3", 4, 4, 4, 4, 4, 4, 2.0, 2.0, [(4, 4)], 0.0000001))
+kernels.append(generator.DenseKernel("sve_mixed_test1", 9, 9, 9, 9, 9, 9, 1.0, 0.0, [(3, 3)] + [x.getBlocksize(9, 9, 1, v_size) for x in blocksize_algs], delta_dp))
+kernels.append(generator.SparseKernel("sve_mixed_test2", 9, 9, 9, 9, 0, 9, 4.0, 2.5, [(3, 3)] + [x.getBlocksize(9, 9, 1, v_size) for x in blocksize_algs], generator.generateMTX(9, 9, 20), delta_dp))
+kernels.append(generator.SparseKernel("sve_mixed_test3", 18, 18, 18, 18, 0, 18, 3.4, -2.5, [(1, 1), (3, 3), (6, 6), (9, 9)] + [x.getBlocksize(18, 18, 1, v_size) for x in blocksize_algs], generator.generateMTX(18, 18, 59), delta_dp))
+kernels.append(generator.SparseKernel("sve_mixed_test4", 80, 80, 80, 80, 0, 80, 0.0, -2.5, [(4, 4), (8, 8)] + [x.getBlocksize(80, 80, 1, v_size) for x in blocksize_algs], generator.generateMTX(80, 80, 312), delta_dp))
+kernels.append(generator.SparseKernel("sve_mixed_test5", 8, 8, 8, 10, 0, 8, 3.0, -0.9, [(2, 2), (4, 4)] + [x.getBlocksize(8, 8, 1, v_size) for x in blocksize_algs], generator.generateMTX(8, 8, 6), delta_dp))
+kernels.append(generator.DenseKernel("sve_mixed_test6", 8, 8, 8, 10, 8, 8, 3.0, -0.9, [(2, 2), (4, 4)] + [x.getBlocksize(8, 8, 1, v_size) for x in blocksize_algs], delta_dp))
 
-kernels.append(generator.SparseKernel("sve_test1", 8, 56, 56, 8, 0, 8, 1.0, 0.0, [(8, 4), (8,1)] + [x.getBlocksize(8, 56, 1, v_size) for x in blocksize_algs], generator.generateMTX(56, 56, 30), 0.0000001))
-kernels.append(generator.DenseKernel("sve_test2", 8, 40, 40, 8, 40, 8, 3.0, 2.0, [(8, 5), (8,2)] + [x.getBlocksize(8, 40, 1, v_size) for x in blocksize_algs], 0.0000001))
-kernels.append(generator.DenseKernel("sve_test3", 8, 56, 56, 8, 56, 8, 0.0, 0.0, [(8, 3), (8, 5)] + [x.getBlocksize(8, 56, 1, v_size) for x in blocksize_algs], 0.0000001))
+kernels.append(generator.DenseKernel("sve_test3", 4, 4, 4, 4, 4, 4, 2.0, 2.0, [(4, 4)], delta_dp))
 
-kernels.append(generator.SparseKernel("sve_arm_only_test1", 2, 3, 4, 2, 0, 2, 1.1233, 0.0, [(2, 1), (2,3)] + [x.getBlocksize(2, 3, 1, v_size) for x in blocksize_algs], generator.generateMTX(4, 3, 5), 0.0000001))
-kernels.append(generator.SparseKernel("sve_arm_only_test2", 2, 3, 4, 20, 0, 14, 1.0, 1.0, [(2, 2), (2,3)] + [x.getBlocksize(2, 3, 1, v_size) for x in blocksize_algs], generator.generateMTX(4, 3, 5), 0.0000001))
-kernels.append(generator.SparseKernel("sve_arm_only_test3", 32, 80, 50, 32, 0, 32, 1.0, 3.0, [(8, 5)] + [x.getBlocksize(32, 80, 1, v_size) for x in blocksize_algs], generator.generateMTX(50, 80, 294), 0.0000001))
-kernels.append(generator.SparseKernel("sve_arm_only_test4", 32, 32, 32, 34, 0, 32, 1.0, 0.0, [(4, 4), (4,3)] + [x.getBlocksize(32, 32, 1, v_size) for x in blocksize_algs], generator.generateMTX(32, 32, 24), 0.0000001))
-kernels.append(generator.SparseKernel("sve_arm_only_test5", 2, 1, 1, 2, 0, 8, 1.0, -1.0, [(2, 1)] + [x.getBlocksize(2, 1, 1, v_size) for x in blocksize_algs], generator.generateMTX(1, 1, 1), 0.0000001))
-kernels.append(generator.SparseKernel("sve_arm_only_test6", 2, 2, 2, 2, 0, 2, 2.0, 234234.123, [(2, 1)] + [x.getBlocksize(2, 2, 1, v_size) for x in blocksize_algs], generator.generateMTX(2, 2, 1), 0.0000001))
-kernels.append(generator.SparseKernel("sve_arm_only_test7", 16, 5, 7, 16, 0, 16, 0.0, -1.123, [(8, 1), (8,2)] + [x.getBlocksize(16, 5, 1, v_size) for x in blocksize_algs], generator.generateMTX(7, 5, 35), 0.0000001))
+kernels.append(generator.SparseKernel("sve_test1", 8, 56, 56, 8, 0, 8, 1.0, 0.0, [(8, 4), (8,1)] + [x.getBlocksize(8, 56, 1, v_size) for x in blocksize_algs], generator.generateMTX(56, 56, 30), delta_dp))
+kernels.append(generator.DenseKernel("sve_test2", 8, 40, 40, 8, 40, 8, 3.0, 2.0, [(8, 5), (8,2)] + [x.getBlocksize(8, 40, 1, v_size) for x in blocksize_algs], delta_dp))
+kernels.append(generator.DenseKernel("sve_test3", 8, 56, 56, 8, 56, 8, 0.0, 0.0, [(8, 3), (8, 5)] + [x.getBlocksize(8, 56, 1, v_size) for x in blocksize_algs], delta_dp))
 
-kernels.append(generator.DenseKernel("sve_arm_only_test8", 2, 3, 4, 2, 4, 2, 1.0, 0.0, [(2, 1), (2,3)] + [x.getBlocksize(2, 3, 1, v_size) for x in blocksize_algs], 0.0000001))
-kernels.append(generator.DenseKernel("sve_arm_only_test9", 2, 3, 4, 20, 12, 14, 2.0, 1.123, [(2, 2), (2,3)] + [x.getBlocksize(2, 3, 1, v_size) for x in blocksize_algs], 0.0000001))
-kernels.append(generator.DenseKernel("sve_arm_only_test10", 32, 80, 50, 32, 50, 32, 0.0, 0.2, [(8, 5)] + [x.getBlocksize(32, 80, 1, v_size) for x in blocksize_algs], 0.0000001))
-kernels.append(generator.DenseKernel("sve_arm_only_test11", 32, 32, 32, 33, 68, 32, 1231.0, 14443.0, [(4, 4), (4,3)] + [x.getBlocksize(32, 32, 1, v_size) for x in blocksize_algs], 0.0000001))
-kernels.append(generator.DenseKernel("sve_arm_only_test12", 2, 1, 1, 2, 1, 8, 1.0, 3.0, [(2, 1)] + [x.getBlocksize(2, 1, 1, v_size) for x in blocksize_algs], 0.0000001))
-kernels.append(generator.DenseKernel("sve_arm_only_test13", 2, 3, 3, 2, 3, 2, 1.0, 0.0, [(2, 1)] + [x.getBlocksize(2, 3, 1, v_size) for x in blocksize_algs], 0.0000001))
-kernels.append(generator.DenseKernel("sve_arm_only_test14", 16, 5, 7, 16, 7, 16, 1.0, 1.0, [(8, 1), (8,2)] + [x.getBlocksize(16, 5, 1, v_size) for x in blocksize_algs], 0.0000001))
+kernels.append(generator.SparseKernel("sve_arm_only_test1", 2, 3, 4, 2, 0, 2, 1.1233, 0.0, [(2, 1), (2,3)] + [x.getBlocksize(2, 3, 1, v_size) for x in blocksize_algs], generator.generateMTX(4, 3, 5), delta_dp))
+kernels.append(generator.SparseKernel("sve_arm_only_test2", 2, 3, 4, 20, 0, 14, 1.0, 1.0, [(2, 2), (2,3)] + [x.getBlocksize(2, 3, 1, v_size) for x in blocksize_algs], generator.generateMTX(4, 3, 5), delta_dp))
+kernels.append(generator.SparseKernel("sve_arm_only_test3", 32, 80, 50, 32, 0, 32, 1.0, 3.0, [(8, 5)] + [x.getBlocksize(32, 80, 1, v_size) for x in blocksize_algs], generator.generateMTX(50, 80, 294), delta_dp))
+kernels.append(generator.SparseKernel("sve_arm_only_test4", 32, 32, 32, 34, 0, 32, 1.0, 0.0, [(4, 4), (4,3)] + [x.getBlocksize(32, 32, 1, v_size) for x in blocksize_algs], generator.generateMTX(32, 32, 24), delta_dp))
+kernels.append(generator.SparseKernel("sve_arm_only_test5", 2, 1, 1, 2, 0, 8, 1.0, -1.0, [(2, 1)] + [x.getBlocksize(2, 1, 1, v_size) for x in blocksize_algs], generator.generateMTX(1, 1, 1), delta_dp))
+kernels.append(generator.SparseKernel("sve_arm_only_test6", 2, 2, 2, 2, 0, 2, 2.0, 234234.123, [(2, 1)] + [x.getBlocksize(2, 2, 1, v_size) for x in blocksize_algs], generator.generateMTX(2, 2, 1), delta_dp))
+kernels.append(generator.SparseKernel("sve_arm_only_test7", 16, 5, 7, 16, 0, 16, 0.0, -1.123, [(8, 1), (8,2)] + [x.getBlocksize(16, 5, 1, v_size) for x in blocksize_algs], generator.generateMTX(7, 5, 35), delta_dp))
+
+kernels.append(generator.DenseKernel("sve_arm_only_test8", 2, 3, 4, 2, 4, 2, 1.0, 0.0, [(2, 1), (2,3)] + [x.getBlocksize(2, 3, 1, v_size) for x in blocksize_algs], delta_dp))
+kernels.append(generator.DenseKernel("sve_arm_only_test9", 2, 3, 4, 20, 12, 14, 2.0, 1.123, [(2, 2), (2,3)] + [x.getBlocksize(2, 3, 1, v_size) for x in blocksize_algs], delta_dp))
+kernels.append(generator.DenseKernel("sve_arm_only_test10", 32, 80, 50, 32, 50, 32, 0.0, 0.2, [(8, 5)] + [x.getBlocksize(32, 80, 1, v_size) for x in blocksize_algs], delta_dp))
+kernels.append(generator.DenseKernel("sve_arm_only_test11", 32, 32, 32, 33, 68, 32, 1231.0, 14443.0, [(4, 4), (4,3)] + [x.getBlocksize(32, 32, 1, v_size) for x in blocksize_algs], delta_dp))
+kernels.append(generator.DenseKernel("sve_arm_only_test12", 2, 1, 1, 2, 1, 8, 1.0, 3.0, [(2, 1)] + [x.getBlocksize(2, 1, 1, v_size) for x in blocksize_algs], delta_dp))
+kernels.append(generator.DenseKernel("sve_arm_only_test13", 2, 3, 3, 2, 3, 2, 1.0, 0.0, [(2, 1)] + [x.getBlocksize(2, 3, 1, v_size) for x in blocksize_algs], delta_dp))
+kernels.append(generator.DenseKernel("sve_arm_only_test14", 16, 5, 7, 16, 7, 16, 1.0, 1.0, [(8, 1), (8,2)] + [x.getBlocksize(16, 5, 1, v_size) for x in blocksize_algs], delta_dp))
 
 kernels.append(generator.DenseKernel("sve_arm_only_test15", 23, 29, 31, 23, 31, 23, 1.32, 0.96, [x.getBlocksize(23, 29, 1, v_size) for x in blocksize_algs], 0.0000001))
-kernels.append(generator.SparseKernel("sve_arm_only_test16", 23, 29, 31, 23, 0, 23, 1.32, 0.96, [x.getBlocksize(23, 29, 1, v_size) for x in blocksize_algs], generator.generateMTX(31, 29, 61), 0.0000001))
+kernels.append(generator.SparseKernel("sve_arm_only_test16", 23, 29, 31, 23, 0, 23, 1.32, 0.96, [x.getBlocksize(23, 29, 1, v_size) for x in blocksize_algs], generator.generateMTX(31, 29, 61), delta_dp))
 
 # TODO: test cases for single precision multiplication.
-#kernels.append(generator.DenseKernelS("sve_mixed_test_S1", 9, 9, 9, 9, 9, 9, 1.0, 0.0, [x.getBlocksize(9, 9, 1, v_size_s) for x in blocksize_algs], 0.0000001))
-
+kernels.append(generator.DenseKernelS("sve_single_prec_test_S1", 9, 9, 9, 9, 9, 9, 1.24, 0.87, [x.getBlocksize(9, 9, 1, v_size_s) for x in blocksize_algs], delta_sp))
+kernels.append(generator.DenseKernelS("sve_single_prec_test_S2", 15, 15, 15, 15, 15, 15, -3.14, 6.28, [x.getBlocksize(15, 15, 1, v_size_s) for x in blocksize_algs], delta_sp))
+kernels.append(generator.DenseKernelS("sve_single_prec_test_S3", 23, 23, 23, 23, 23, 23, 1.5, -0.66, [x.getBlocksize(23, 23, 1, v_size_s) for x in blocksize_algs], delta_sp))
+kernels.append(generator.DenseKernelS("sve_single_prec_test_S4", 23, 31, 13, 23, 13, 23, 2.0, 0.0, [x.getBlocksize(23, 31, 1, v_size_s) for x in blocksize_algs], delta_sp))
+kernels.append(generator.SparseKernelS("sve_single_prec_test_S5", 9, 9, 9, 9, 0, 9, 1.24, 0.87, [x.getBlocksize(9, 9, 1, v_size_s) for x in blocksize_algs], generator.generateMTX(9, 9, 8), delta_sp))
+kernels.append(generator.SparseKernelS("sve_single_prec_test_S6", 15, 15, 15, 15, 0, 15, -3.14, 6.28, [x.getBlocksize(15, 15, 1, v_size_s) for x in blocksize_algs], generator.generateMTX(15, 15, 22), delta_sp))
+kernels.append(generator.SparseKernelS("sve_single_prec_test_S7", 23, 23, 23, 23, 0, 23, 1.5, -0.66, [x.getBlocksize(23, 23, 1, v_size_s) for x in blocksize_algs], generator.generateMTX(23, 23, 52), delta_sp))
+kernels.append(generator.SparseKernelS("sve_single_prec_test_S8", 23, 31, 13, 23, 0, 23, 2.0, 0.0, [x.getBlocksize(23, 31, 1, v_size_s) for x in blocksize_algs], generator.generateMTX(13, 31, 40), delta_sp))
 
 generator.make(kernels, "arm_sve")

--- a/tests/unit_tests_arm_sve.py
+++ b/tests/unit_tests_arm_sve.py
@@ -14,6 +14,7 @@ kernels = []
 delta_sp = 1e-6
 delta_dp = 1e-7
 
+# test cases for double precision multiplication
 kernels.append(generator.DenseKernel("sve_mixed_test1", 9, 9, 9, 9, 9, 9, 1.0, 0.0, [(3, 3)] + [x.getBlocksize(9, 9, 1, v_size) for x in blocksize_algs], delta_dp))
 kernels.append(generator.SparseKernel("sve_mixed_test2", 9, 9, 9, 9, 0, 9, 4.0, 2.5, [(3, 3)] + [x.getBlocksize(9, 9, 1, v_size) for x in blocksize_algs], generator.generateMTX(9, 9, 20), delta_dp))
 kernels.append(generator.SparseKernel("sve_mixed_test3", 18, 18, 18, 18, 0, 18, 3.4, -2.5, [(1, 1), (3, 3), (6, 6), (9, 9)] + [x.getBlocksize(18, 18, 1, v_size) for x in blocksize_algs], generator.generateMTX(18, 18, 59), delta_dp))
@@ -46,7 +47,7 @@ kernels.append(generator.DenseKernel("sve_arm_only_test14", 16, 5, 7, 16, 7, 16,
 kernels.append(generator.DenseKernel("sve_arm_only_test15", 23, 29, 31, 23, 31, 23, 1.32, 0.96, [x.getBlocksize(23, 29, 1, v_size) for x in blocksize_algs], 0.0000001))
 kernels.append(generator.SparseKernel("sve_arm_only_test16", 23, 29, 31, 23, 0, 23, 1.32, 0.96, [x.getBlocksize(23, 29, 1, v_size) for x in blocksize_algs], generator.generateMTX(31, 29, 61), delta_dp))
 
-# TODO: test cases for single precision multiplication.
+# test cases for single precision multiplication
 kernels.append(generator.DenseKernelS("sve_single_prec_test_S1", 9, 9, 9, 9, 9, 9, 1.24, 0.87, [x.getBlocksize(9, 9, 1, v_size_s) for x in blocksize_algs], delta_sp))
 kernels.append(generator.DenseKernelS("sve_single_prec_test_S2", 15, 15, 15, 15, 15, 15, -3.14, 6.28, [x.getBlocksize(15, 15, 1, v_size_s) for x in blocksize_algs], delta_sp))
 kernels.append(generator.DenseKernelS("sve_single_prec_test_S3", 23, 23, 23, 23, 23, 23, 1.5, -0.66, [x.getBlocksize(23, 23, 1, v_size_s) for x in blocksize_algs], delta_sp))


### PR DESCRIPTION
Pull request for the single-precision extension to the SVE-based generator. I included additional test cases to PSpaMM/tests/unit_tests_arm_sve.py

I have found an issue when compiling the sve unit tests using gcc11. I documented the issue in the README file within PSpaMM/tests/ and changed the Makefile to use clang instead of gcc for the SVE version of PSpaMM.