### PR TITLE
Introduce SVE prefetching

### DIFF
--- a/codegen/architectures/arm_sve/generator.py
+++ b/codegen/architectures/arm_sve/generator.py
@@ -183,7 +183,7 @@ void {funcName} (const {real_type}* A, const {real_type}* B, {real_type}* C, con
         prec = self.get_precision()
 
         # Determine whether we use prefetching and if we are currently operating on C
-        do_prefetch = prefetching is not None and cursor.name == "C" and store
+        do_prefetch = self.prefetch_reg is not None and cursor.name == "C" and store
 
         b_row, b_col, i, _ = cursor.get_block(cursor_ptr, block_offset)
 
@@ -335,6 +335,9 @@ void {funcName} (const {real_type}* A, const {real_type}* B, {real_type}* C, con
         return asm
 
     def init_prefetching(self, prefetching):
+        #TODO: currently, SVE prefetching brings at best equal performance compared to no prefetching
+        # for now disable it -> if we find a way to get better performance with prefetching, delete the next line
+        prefetching = None  # disable prefetching and make it easy to enable
         if prefetching is None:
             prefetch_reg = None
             prefetching_mov = ''

--- a/codegen/architectures/arm_sve/generator.py
+++ b/codegen/architectures/arm_sve/generator.py
@@ -79,7 +79,7 @@ void {funcName} (const {real_type}* A, const {real_type}* B, {real_type}* C, con
         alpha_reg = [z(0, prec), z(0, prec)]
         beta_reg = [z(1, prec), z(1, prec)]
 
-        starting_regs = [r(0), r(1), r(2)]
+        starting_regs = [r(0), r(1), r(2), r(3), r(4), r(6)]  # r6 is needed for predicate creation, r5 is added int init_prefetching()
 
         additional_regs = [r(11), l("0.0"), r(10), r(8)]  # r10 used for scaling offsets
 
@@ -129,7 +129,7 @@ void {funcName} (const {real_type}* A, const {real_type}* B, {real_type}* C, con
         # Wn adresses the lower 32 bits of Xn
         # generally: Xn/Wn "[...] are two separate ways of looking at the same register"
         # this means we can load alpha/beta into x3/x4 even if they are floats (32 bits)
-        dup_alpha = "\t\"dup z0.{suffix}, {gen_reg}3{eol}\"\n\t"  # define broadcasting of alpha
+        dup_alpha = "//Broadcasted alpha and beta into z0/z1 so that efficient multiplication is possible\n\t\"dup z0.{suffix}, {gen_reg}3{eol}\"\n\t"  # define broadcasting of alpha
         dup_beta = "\"dup z1.{suffix}, {gen_reg}4{eol}\"\n\t"   # define broadcasting of beta
 
         comment = "//p7 denotes the 'all-true' predicate and, if given, p0 denotes the 'bm % v_size' predicate\n\t"
@@ -138,7 +138,7 @@ void {funcName} (const {real_type}* A, const {real_type}* B, {real_type}* C, con
         # https://developer.arm.com/documentation/ddi0596/2020-12/Shared-Pseudocode/AArch64-Functions?lang=en#impl-aarch64.DecodePredCount.2
         # 'ptrue' doesnt work for initialising overhead predicate when using single precision -> see valid patterns from above
         # overhead = "\"ptrue p0.{suffix}, #{overhead}{eol}\"\n\t" if bm != 0 else ""    # define overhead predicate
-        overhead = "\"mov {gen_reg}5, #{overhead}{eol}\"\n\t\"whilelo p0.{suffix}, {gen_reg}zr, {gen_reg}5{eol}\"\n\t" if bm != 0 else ""
+        overhead = "\"mov {gen_reg}5, #{overhead}{eol}\"\n\t\"whilelo p0.{suffix}, {gen_reg}zr, {gen_reg}6{eol}\"\n\t" if bm != 0 else ""
         all_true = "\"ptrue p7.{suffix}, #31{eol}\""                             # define all true predicate
         init_registers = (dup_alpha + dup_beta + comment + overhead + all_true).format(suffix=p_suffix,
                                                                                        gen_reg=gen_reg,

--- a/codegen/architectures/arm_sve/inlineprinter.py
+++ b/codegen/architectures/arm_sve/inlineprinter.py
@@ -169,16 +169,11 @@ class InlinePrinter(Visitor):
             raise NotImplementedError()
         self.addLine(s, stmt.comment)
 
-    #  instead of dest: Register
-    def visitPrefetch(self, stmt: PrefetchStmt):#, access_type: str, prec: str, p: Register):
-        # call visitPrefetch from within load/store methods, avoid cluttering non sve-specific files (ast.py, matmul.py, etc.)
+    def visitPrefetch(self, stmt: PrefetchStmt):
         # https://stackoverflow.com/questions/37070/what-is-the-meaning-of-non-temporal-memory-accesses-in-x86#:~:text=Data%20referenced%20by%20a%20program,%2C%20is%20often%20non%2Dtemporal.
-        # temporal vs non-temporal data? Do we see a difference in execution time depending on the type of prefetching?
-        # TODO: we could dynamically choose where to prefetch data to (L1 vs L2), maybe this is irrelevant though
-        cache_level = "L1"
-        temporality = "STRM"
+        cache_level = "L1"  # specify cache level to which we prefetch
+        temporality = "STRM"  # could use "STRM" for non-temporal prefetching if needed
         xn = stmt.dest.ugly_base
-        # TODO: how do we get the offset, just from load/store instruction?
         offset = stmt.dest.ugly_offset
         src_string = "[{}, {}, MUL VL]".format(xn, offset)
         p = self.p_string(stmt.pred)

--- a/codegen/architectures/arm_sve/inlineprinter.py
+++ b/codegen/architectures/arm_sve/inlineprinter.py
@@ -172,7 +172,7 @@ class InlinePrinter(Visitor):
     def visitPrefetch(self, stmt: PrefetchStmt):
         # https://stackoverflow.com/questions/37070/what-is-the-meaning-of-non-temporal-memory-accesses-in-x86#:~:text=Data%20referenced%20by%20a%20program,%2C%20is%20often%20non%2Dtemporal.
         cache_level = "L1"  # specify cache level to which we prefetch
-        temporality = "STRM"  # could use "STRM" for non-temporal prefetching if needed
+        temporality = "KEEP"  # could use "STRM" for non-temporal prefetching if needed
         xn = stmt.dest.ugly_base
         offset = stmt.dest.ugly_offset
         src_string = "[{}, {}, MUL VL]".format(xn, offset)

--- a/codegen/architectures/arm_sve/inlineprinter.py
+++ b/codegen/architectures/arm_sve/inlineprinter.py
@@ -180,7 +180,7 @@ class InlinePrinter(Visitor):
         xn = stmt.dest.ugly_base
         # TODO: how do we get the offset, just from load/store instruction?
         offset = stmt.dest.ugly_offset
-        src_string = "[{}, #{}, MUL VL]".format(xn, offset)
+        src_string = "[{}, {}, MUL VL]".format(xn, offset)
         p = self.p_string(stmt.pred)
         prec = "d" if stmt.precision == Precision.DOUBLE else "w"
         s = "prf{} P{}{}{}, {}{}".format(prec, stmt.access_type, cache_level, temporality, p.split('/')[0], src_string)

--- a/codegen/architectures/arm_sve/operands.py
+++ b/codegen/architectures/arm_sve/operands.py
@@ -89,6 +89,10 @@ class MemoryAddress_ARM(MemoryAddress):
         return "[{}, {}, MUL VL]".format(self.base.ugly, self.disp)
 
     @property
+    def clobbered(self):
+        return self.base
+
+    @property
     def ugly_no_vl_scaling(self):
         return "[{}, {}]".format(self.base.ugly, self.disp)
 

--- a/codegen/ast.py
+++ b/codegen/ast.py
@@ -74,6 +74,10 @@ class StoreStmt(AsmStmt):
 
 class PrefetchStmt(AsmStmt):
     dest = None
+    # used in arm_sve:
+    pred = None
+    precision = None
+    access_type = None
 
     def accept(self, visitor: "Visitor"):
         visitor.visitPrefetch(self)

--- a/codegen/sugar.py
+++ b/codegen/sugar.py
@@ -118,10 +118,14 @@ def st(src: Union[Operand, int], dest: Operand, vector: bool, comment:str = None
         stmt.typ = AsmType.i64
     return stmt
 
-def prefetch(dest: Operand, comment:str = None):
+def prefetch(dest: Operand, comment:str = None, pred: Register = None, precision: str = None, access_type: str = None):
     stmt = PrefetchStmt()
     stmt.dest = dest
     stmt.comment = comment
+    # used in arm_sve:
+    stmt.pred = pred
+    stmt.precision = precision
+    stmt.access_type = access_type
     return stmt
 
 def data(value: Union[Operand, int], asmType=AsmType.i64):

--- a/matmul.py
+++ b/matmul.py
@@ -140,6 +140,8 @@ class MatMul:
 
         if ldb == 0:
             pattern = Matrix.load(mtx_filename)
+            if self.is_sve:
+                self.generator.set_sparse()
         else:
             mtx = numpy.zeros((k, n))
             for i in range(k):

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -7,7 +7,7 @@ CXXFLAGSNEON=-std=c++17 -O3 -mcpu=native -fopenmp -Wall -g
 all: sve_testsuite neon_testsuite
 
 sve_testsuite: sve_testsuite.cpp
-	${CXXCLANG} ${CXXFLAGS} $< -o sve_testsuite
+	${CXX} ${CXXFLAGS} $< -o sve_testsuite
 
 neon_testsuite: testsuite.cpp
 	${CXX} ${CXXFLAGSNEON} $< -o neon_testsuite

--- a/tests/sve_testsuite_generator.py
+++ b/tests/sve_testsuite_generator.py
@@ -12,6 +12,14 @@ DenseKernel = namedtuple('DenseKernel', 'name m n k lda ldb ldc alpha beta block
 SparseKernelS = namedtuple('SparseKernelS', 'name m n k lda ldb ldc alpha beta block_sizes mtx delta')
 DenseKernelS = namedtuple('DenseKernelS', 'name m n k lda ldb ldc alpha beta block_sizes delta')
 
+setup_prefetching = """
+template <typename T>
+void setup_prefetch(T* prefetch, T* matrix, unsigned n, unsigned ldc) {
+ posix_memalign(reinterpret_cast<void **>(&prefetch), 64, {ldc}*{n}*sizeof({T}));
+ std::memcpy(prefetch, matrix, {ldc}*{n}*sizeof({T}));
+}
+"""
+
 def generateMTX(k, n, nnz):
     return test_generator.generateMTX(k, n, nnz)
 
@@ -54,7 +62,7 @@ def make(kernels, arch):
 
             additional_args = ['--output_funcname', name, '--output_filename', arch + '/' + name + '.h',
                                '--output_overwrite']
-            additional_args += ['--bm', str(bm), '--bn', str(bn), '--arch', arch]
+            additional_args += ['--bm', str(bm), '--bn', str(bn), '--arch', arch, '--prefetching', 'BL2viaC']
 
             try:
                 subprocess.check_output(arguments + additional_args, stderr=subprocess.STDOUT)
@@ -66,12 +74,15 @@ def make(kernels, arch):
     f.write('\n')
     # necessary functions are defined in testsuite_generator.py
     f.write(test_generator.function_definitions)
+    f.write(setup_prefetching)
+    f.write(test_generator.setup_main)
     # add variable declarations for single precision test cases
     if include_single_prec:
-        f.write("""
-    std::tuple<float*, float*, float*, float*, float*> fpointers;
-    float falpha; float fbeta;
-    """)
+        f.write("""  std::tuple<float*, float*, float*, float*, float*> fpointers;
+  float falpha; float fbeta;
+  double* prefetch;
+  float* fprefetch;
+  """)
 
     for kern in kernels:
 
@@ -92,10 +103,11 @@ def make(kernels, arch):
             f.write("""
   {p}alpha = {alpha}; {p}beta = {beta}; ldb = {ldb};
   {p}pointers = pre<{T}>({m}, {n}, {k}, {lda}, ldb, {ldc}, "{mtx}");
-  {name}(std::get<0>({p}pointers), std::get<{sparse}>({p}pointers), std::get<3>({p}pointers), {p}alpha, {p}beta, nullptr);
+  setup_prefetch({p}prefetch, std::get<3>({p}pointers), {n}, {ldc});
+  {name}(std::get<0>({p}pointers), std::get<{sparse}>({p}pointers), std::get<3>({p}pointers), {p}alpha, {p}beta, {p}prefetch);
   result = post<{T}>({m}, {n}, {k}, {lda}, &ldb, {ldc}, &{p}alpha, &{p}beta, std::get<0>({p}pointers), std::get<1>({p}pointers), std::get<3>({p}pointers), std::get<4>({p}pointers), {delta:.7f});
   results.push_back(std::make_tuple("{name}", result));
-  free(std::get<0>({p}pointers)); free(std::get<1>({p}pointers)); free(std::get<2>({p}pointers)); free(std::get<3>({p}pointers)); free(std::get<4>({p}pointers));
+  free(std::get<0>({p}pointers)); free(std::get<1>({p}pointers)); free(std::get<2>({p}pointers)); free(std::get<3>({p}pointers)); free(std::get<4>({p}pointers));  free({p}prefetch);
 """.format(m=kern.m, n=kern.n, k=kern.k, lda=kern.lda, ldb=kern.ldb, ldc=kern.ldc, alpha=kern.alpha, beta=kern.beta,
            mtx=mtx, delta=kern.delta, name=name, sparse=2 if kern.ldb == 0 else 1, p=prec, T="float" if prec == 'f' else "double"))
 

--- a/tests/sve_testsuite_generator.py
+++ b/tests/sve_testsuite_generator.py
@@ -15,8 +15,8 @@ DenseKernelS = namedtuple('DenseKernelS', 'name m n k lda ldb ldc alpha beta blo
 setup_prefetching = """
 template <typename T>
 void setup_prefetch(T* prefetch, T* matrix, unsigned n, unsigned ldc) {
- posix_memalign(reinterpret_cast<void **>(&prefetch), 64, {ldc}*{n}*sizeof({T}));
- std::memcpy(prefetch, matrix, {ldc}*{n}*sizeof({T}));
+ posix_memalign(reinterpret_cast<void **>(&prefetch), 64, ldc*n*sizeof(T));
+ std::memcpy(prefetch, matrix, ldc*n*sizeof(T));
 }
 """
 

--- a/tests/testsuite_generator.py
+++ b/tests/testsuite_generator.py
@@ -134,7 +134,9 @@ int post(unsigned M, unsigned N, unsigned K, unsigned LDA, unsigned* LDB, unsign
 
   return 1;
 }
+"""
 
+setup_main = """
 int main()
 {
   std::vector<std::tuple<std::string, int>> results;
@@ -241,6 +243,7 @@ def make(kernels, arch):
     f.write('\n')
 
     f.write(function_definitions)
+    f.write(setup_main)
 
     for kern in kernels:
 


### PR DESCRIPTION
This PR introduces prefetching for the SVE generator of PSpaMM.

However, when I benchmarked the generator's performance within SeisSol, the prefetching version never achieved the same performances as the non-prefetching version. Because of this, **prefetching is currently disabled** within this PR. I added it anyway for the sake of completeness and because there is probably a fix that I am not seeing at the moment.

If a fix is found that would make the prefetch version faster than the non-prefetch one, we can simply remove the [highlighted line of code](https://github.com/montrie/PSpaMM_SVE/commit/220a5535c2fc701f1d881dba4f475c41f452c0fe#diff-cbd301cef0b1f7eeae6a18ac85e99a8afc3367f6dbc57252f4f14d782147f937R340) at the end of the `init_prefetching()` method. Removing that line of code is also necessary if one would want to generate a SVE testsuite that includes prefetching.