### PR TITLE
Update inlineprinter.py

### DIFF
--- a/codegen/architectures/knl/inlineprinter.py
+++ b/codegen/architectures/knl/inlineprinter.py
@@ -96,7 +96,7 @@ class InlinePrinter(Visitor):
             if isinstance(stmt.src, Constant) and stmt.src.value == 0:
                 s = "vpxord {}, {}, {}".format(stmt.dest.ugly,stmt.dest.ugly,stmt.dest.ugly)
             else:
-                s = "vmovap{} {}, {}".format(self.precision, src_str,stmt.dest.ugly)
+                s = "vmovup{} {}, {}".format(self.precision, src_str,stmt.dest.ugly)
         else:
             raise NotImplementedError()
         self.addLine(s, stmt.comment)


### PR DESCRIPTION
Address the changes discussed in https://github.com/SeisSol/SeisSol/issues/902 . I.e.: don't force alignment during a mov operation (effectively: movapd -> movupd; or `_mm512_load_p{d,s}` becomes `_mm512_loadu_p{d,s}`).