### PR TITLE
SVE for 128, 256, 1024, and 2048 Bits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,10 @@ __pycache__/
 
 # Testing (for now)
 tests/arm/
-tests/arm_sve/
+tests/arm_sve*/
 tests/hsw/
 tests/knl/
 tests/testsuite.cpp
+tests/arm_*testsuite.cpp
+tests/sve*-test
 a.out

--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ Currently Intel Xeon Phi 'Knights Landing' (AVX512), Haswell/Zen2 (AVX2), and AR
 
 Usage: 
 
-./pspamm M N K LDA LDB LDC ALPHA BETA --arch {arm,arm_sve,knl,hsw}
+./pspamm M N K LDA LDB LDC ALPHA BETA --arch {arm,arm_sve{128,256,512,1024,2048},knl,hsw}
 
 --mtx_filename MTX_FILE_PATH --output_funcname FUNCTION_NAME --output_filename OUTPUT_NAME

--- a/codegen/architectures/arm/generator.py
+++ b/codegen/architectures/arm/generator.py
@@ -30,7 +30,8 @@ void {funcName} (const {real_type}* A, const {real_type}* B, {real_type}* C, {re
     pspamm_num_total_flops += {flop};
     #endif
 
-}}}};"""
+}}}};
+"""
 
     def get_v_size(self):
         if self.precision == Precision.DOUBLE:

--- a/tests/runall-sve.sh
+++ b/tests/runall-sve.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# maybe do PYTHONPATH=$(pwd)/..:$PYTHONPATH
+
+echo "SVE GEMM test. Right now, we do not test all multiples of 128 bit. Mostly powers of two, since gcc may not support others."
+
+for BITLEN in 128 256 512 1024 2048
+do
+    echo ""
+    echo ""
+    echo "Testing $BITLEN bit SVE register GEMM"
+    python unit_tests_arm_sve.py $BITLEN
+    aarch64-linux-gnu-g++ -static -march=armv8.2-a+sve -msve-vector-bits=${BITLEN} arm_sve${BITLEN}_testsuite.cpp -o sve${BITLEN}-test
+    qemu-aarch64-static -cpu max,sve${BITLEN}=on,sve-default-vector-length=-1 ./sve${BITLEN}-test
+done
+
+echo "All tests done. Bye!"

--- a/tests/testsuite_generator.py
+++ b/tests/testsuite_generator.py
@@ -125,12 +125,15 @@ int post(unsigned M, unsigned N, unsigned K, unsigned LDA, unsigned* LDB, unsign
 
   gemm_ref(M, N, K, LDA, *LDB, LDC, *ALPHA, *BETA, A, B, Cref);
     
-  for(int i = 0; i < M; i++)
-    for(int j = 0; j < N; j++)
+  for(int i = 0; i < M; i++) {
+    for(int j = 0; j < N; j++) {
       // we use the relative error instead of the absolute error because of an issue we found for sparse single precision 
       // kernels presumably due to limited precision of floats
-      if(std::abs((C[i + j * LDC] - Cref[i + j * LDC])) / Cref[i + j * LDC] > DELTA)
+      if(std::abs((C[i + j * LDC] - Cref[i + j * LDC])) / Cref[i + j * LDC] > DELTA) {
         return 0;
+      }
+    }
+  }
 
   return 1;
 }
@@ -177,7 +180,8 @@ end_of_testsuite = """
   printf("\\n%i out of %lu test successful!\\n", correct, results.size());
 
   return 0;
-}"""
+}
+"""
 
 
 def generateMTX(k, n, nnz):

--- a/tests/unit_tests_arm_sve.py
+++ b/tests/unit_tests_arm_sve.py
@@ -4,15 +4,23 @@ import sve_testsuite_generator as generator
 
 import scripts.max_arm_sve as max_sve
 
+import sys
+
+v_len = 4
+
+if len(sys.argv) == 2:
+    v_len = int(sys.argv[1]) // 128
+
 blocksize_algs = [max_sve]
-v_size = 8
-v_size_s = 16
+v_size = 2 * v_len
+v_size_s = 4 * v_len
+bitlen = v_len * 128
 kernels = []
 
 # define the maximum allowed difference between elements of our solution and the reference solution for
 # double and single precision
-delta_sp = 1e-6
-delta_dp = 1e-7
+delta_sp = 1e-4 # epsilon is around e-7 => /2 ... For most cases, 1e-6 is enough
+delta_dp = 1e-7 # epsilon is around e-15 => /2
 
 # test cases for double precision multiplication
 kernels.append(generator.DenseKernel("sve_mixed_test1", 9, 9, 9, 9, 9, 9, 1.0, 0.0, [(3, 3)] + [x.getBlocksize(9, 9, 1, v_size) for x in blocksize_algs], delta_dp))
@@ -57,4 +65,4 @@ kernels.append(generator.SparseKernelS("sve_single_prec_test_S6", 15, 15, 15, 15
 kernels.append(generator.SparseKernelS("sve_single_prec_test_S7", 23, 23, 23, 23, 0, 23, 1.5, -0.66, [x.getBlocksize(23, 23, 1, v_size_s) for x in blocksize_algs], generator.generateMTX(23, 23, 52), delta_sp))
 kernels.append(generator.SparseKernelS("sve_single_prec_test_S8", 23, 31, 13, 23, 0, 23, 2.0, 0.0, [x.getBlocksize(23, 31, 1, v_size_s) for x in blocksize_algs], generator.generateMTX(13, 31, 40), delta_sp))
 
-generator.make(kernels, "arm_sve")
+generator.make(kernels, f"arm_sve{bitlen}")


### PR DESCRIPTION
This PR extends the existing functionality of the `arm_sve` target to support other register lengths. That includes 128, 256, 1024, and 2048 bits. While nominally, we also may support other multiples of 128 bits (e.g. 384 bit), and the generator will generate code for them, only the powers of two have been successfully tested. The targets are named `arm_sve128`, `arm_sve256`, and so on.

Testing methodology: use ARM64 GCC to compile for ARM with SVE and a fixed vector length. Then, use QEMU to simulate the afore-concerned processor. In my case, I used `aarch64-linux-gnu-gcc` (supports SVE in lengths 128,256,512,1024,2048), and ARM V8.2 with SVE; also I compiled with `-static`, since I then used `qemu-aarch64-static` (i.e. static userspace QEMU) to run the program (without static, some libraries could not be found), and selected a CPU which had the maximum SVE register length I wanted selected and ready to use.

The following comments ought to be made:

* There was a tiny bug in the `tests/sve_testsuite_generator.py`: the `prefetch` argument needs to be given as `T*&` instead of just `T*`, as the pointer is assigned to. (not doing that caused a segfault)
* for single precision, the testing error had to be reduced to 1e-4 (from 1e-6 before). The reason for that were one or two unfortunate matrix entries where the relative error rose to above 1e-6 and in one case above 1e-5. Notes: this problem only concerned one or two entries in the entire matrix. Also, it only occurred for register lengths 128 and 256.