### PR TITLE
add init file

### DIFF
--- a/pspamm.py
+++ b/pspamm.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python3
+if __name__=='__main__':
+    import pspamm.pspamm
+    pspamm.pspamm.main()

--- a/pspamm/__init__.py
+++ b/pspamm/__init__.py
@@ -1,0 +1,1 @@
+from pspamm import *


### PR DESCRIPTION
Else, I get `ModuleNotFoundError: No module named 'pspamm.architecture'; 'pspamm' is not a package`


```
[csbcfmpd@login211-1 build]$ python
Python 3.9.9 (main, Dec  1 2021, 15:05:04) 
[GCC 10.1.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import pspamm.architecture
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/mnt/lustre/scratch/nlsas/home/csic/bcf/mpd/Simulation/spack_SeisSol/spack_packages/linux-rocky8-icelake/intel-2021.3.0/py-pspamm-develop-nlggzcg2c2k36xgtowu3cok5avba3ai6/pspamm/pspamm.py", line 5, in <module>
    import pspamm.architecture
ModuleNotFoundError: No module named 'pspamm.architecture'; 'pspamm' is not a package
>>> 
```