### PR TITLE
Fix clobbering and NVHPC register names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ build/
 __pycache__/
 PspaMM.egg-info/
 
+.vscode/
+
 # Testing (for now)
 tests/arm/
 tests/arm_sve*/

--- a/pspamm/codegen/architectures/arm/generator.py
+++ b/pspamm/codegen/architectures/arm/generator.py
@@ -69,8 +69,8 @@ void {funcName} (const {real_type}* A, const {real_type}* B, {real_type}* C, {re
                         ) -> Block:
 
         asm = block("Broadcast alpha and beta so that efficient multiplication is possible")
-
-        
+        asm.add(mov(alpha_reg[0], alpha_reg[1], True))
+        asm.add(mov(beta_reg[0], beta_reg[1], True))
         return asm
 
     def make_scaling_offsets(self,

--- a/pspamm/codegen/architectures/arm_sve/generator.py
+++ b/pspamm/codegen/architectures/arm_sve/generator.py
@@ -104,6 +104,8 @@ void {funcName} (const {real_type}* A, const {real_type}* B, {real_type}* C, con
                         ) -> Block:
 
         asm = block("Broadcasted alpha and beta into z0/z1 so that efficient multiplication is possible")
+        asm.add(mov(alpha_reg[0], alpha_reg[1], True))
+        asm.add(mov(beta_reg[0], beta_reg[1], True))
         return asm
 
     def make_scaling_offsets(self,

--- a/pspamm/codegen/architectures/arm_sve/operands.py
+++ b/pspamm/codegen/architectures/arm_sve/operands.py
@@ -56,7 +56,8 @@ class Register_ARM(Register):
 
     @property
     def clobbered(self):
-        return (self.value.split(".")[0]).replace("x", "r")
+        # removed [this comment should stay here for now---in case there's some compiler expecting it]: .replace("x", "r")
+        return (self.value.split(".")[0])
 
     @property
     def ugly_scalar(self):


### PR DESCRIPTION
As the title says: the ARM-NEON and ARM-SVE backends didn't clobber all registers. Also, we fix the register names, so that NVHPC lets the code pass.