### PR TITLE
Free up statically allocated vector registers for alpha/beta values

### DIFF
--- a/pspamm/codegen/architectures/arm/generator.py
+++ b/pspamm/codegen/architectures/arm/generator.py
@@ -50,9 +50,9 @@ void {funcName} (const {real_type}* A, const {real_type}* B, {real_type}* C, {re
                                                    for r in range(vm)])
 
         # get vector register number of the first vector in B_regs
-        b_reg = B_regs[0, 0].ugly.split(".")[0][1:]
-        alpha_reg = [v(int(b_reg)), v(int(b_reg))]
-        beta_reg = [v(int(b_reg) + 1), v(int(b_reg) + 1)]
+        b_reg = vm*bk
+        alpha_reg = [v(b_reg), v(b_reg)]
+        beta_reg = [v(b_reg + 1), v(b_reg + 1)]
 
 
         starting_regs = [r(0), r(1), r(2)]

--- a/pspamm/codegen/architectures/arm/inlineprinter.py
+++ b/pspamm/codegen/architectures/arm/inlineprinter.py
@@ -61,6 +61,12 @@ class InlinePrinter(Visitor):
         s = "fmul {}, {}, {}".format(a,m,b)
         self.addLine(s, stmt.comment)
 
+    def visitBcst(self, stmt: BcstStmt):
+        b = stmt.bcast_src.ugly
+        a = stmt.dest.ugly
+        s = "dup {}, {}".format(a, b)
+        self.addLine(s, stmt.comment)
+
     def visitAdd(self, stmt: AddStmt):
         if isinstance(stmt.src, Constant) and (stmt.src.value > 4095 or stmt.src.value < -4095):
             if (stmt.src.value >> 16) & 0xFFFF > 0 and stmt.src.value < 0:

--- a/pspamm/codegen/architectures/arm_sve/generator.py
+++ b/pspamm/codegen/architectures/arm_sve/generator.py
@@ -85,7 +85,6 @@ void {funcName} (const {real_type}* A, const {real_type}* B, {real_type}* C, con
         B_regs = Matrix([[z(max(vm, 1) * bk + bn * r + c, prec) for c in range(bn)] for r in range(bk)])
         C_regs = Matrix([[z(32 - max(vm, 1) * bn + max(vm, 1) * c + r, prec) for c in range(bn)] for r in range(max(vm, 1))])
 
-#        temp = B_regs[0, 0].ugly.split(".")
         b_reg, b_prec = B_regs[0, 0].ugly[1:].split(".") #temp[0][1:], temp[1]
         alpha_reg = [z(int(b_reg), b_prec), z(int(b_reg), b_prec)]
         beta_reg = [z(int(b_reg) + 1, b_prec), z(int(b_reg) + 1, b_prec)]

--- a/pspamm/codegen/architectures/arm_sve/generator.py
+++ b/pspamm/codegen/architectures/arm_sve/generator.py
@@ -85,9 +85,9 @@ void {funcName} (const {real_type}* A, const {real_type}* B, {real_type}* C, con
         B_regs = Matrix([[z(max(vm, 1) * bk + bn * r + c, prec) for c in range(bn)] for r in range(bk)])
         C_regs = Matrix([[z(32 - max(vm, 1) * bn + max(vm, 1) * c + r, prec) for c in range(bn)] for r in range(max(vm, 1))])
 
-        b_reg, b_prec = B_regs[0, 0].ugly[1:].split(".") #temp[0][1:], temp[1]
-        alpha_reg = [z(int(b_reg), b_prec), z(int(b_reg), b_prec)]
-        beta_reg = [z(int(b_reg) + 1, b_prec), z(int(b_reg) + 1, b_prec)]
+        b_reg = max(vm, 1) * bk
+        alpha_reg = [z(b_reg, prec), z(b_reg, prec)]
+        beta_reg = [z(b_reg + 1, prec), z(b_reg + 1, prec)]
 
         starting_regs = [r(0), r(1), r(2), r(3), r(4), r(6)]  # r6 is needed for predicate creation, r5 is added in init_prefetching()
 

--- a/pspamm/codegen/architectures/arm_sve/inlineprinter.py
+++ b/pspamm/codegen/architectures/arm_sve/inlineprinter.py
@@ -61,6 +61,16 @@ class InlinePrinter(Visitor):
         s = "fmul {}, {}{}, {}".format(a, p, b, m)
         self.addLine(s, stmt.comment)
 
+    def visitBcst(self, stmt: BcstStmt):
+        # Used to broadcast a scalar register into a vector register
+        b = stmt.bcast_src.ugly
+        a = stmt.dest.ugly
+        # make sure the src register is a W register when using single precision
+        if a[-1] == 's':
+            b = "w" + b[1:]
+        s = "dup {}, {}".format(a, b)
+        self.addLine(s, stmt.comment)
+
     def visitAdd(self, stmt: AddStmt):
         if isinstance(stmt.src, Constant) and (stmt.src.value > 4095 or stmt.src.value < -4095):
             # This condition is probably related to immediate values being restricted to 12 bits for add instructions

--- a/pspamm/codegen/architectures/arm_sve/inlineprinter.py
+++ b/pspamm/codegen/architectures/arm_sve/inlineprinter.py
@@ -66,7 +66,7 @@ class InlinePrinter(Visitor):
         b = stmt.bcast_src.ugly
         a = stmt.dest.ugly
         # make sure the src register is a W register when using single precision
-        if stmt.dest.ugly_precision == 's':
+        if self.precision == Precision.SINGLE:
             b = "w" + b[1:]
         s = "dup {}, {}".format(a, b)
         self.addLine(s, stmt.comment)

--- a/pspamm/codegen/architectures/arm_sve/inlineprinter.py
+++ b/pspamm/codegen/architectures/arm_sve/inlineprinter.py
@@ -66,7 +66,7 @@ class InlinePrinter(Visitor):
         b = stmt.bcast_src.ugly
         a = stmt.dest.ugly
         # make sure the src register is a W register when using single precision
-        if a[-1] == 's':
+        if stmt.dest.ugly_precision == 's':
             b = "w" + b[1:]
         s = "dup {}, {}".format(a, b)
         self.addLine(s, stmt.comment)

--- a/pspamm/codegen/architectures/hsw/generator.py
+++ b/pspamm/codegen/architectures/hsw/generator.py
@@ -21,7 +21,7 @@ void {{funcName}} (const {{real_type}}* A, const {{real_type}}* B, {{real_type}}
 {prefetching_mov}
 {{body_text}}
 
-    : : "m"(A), "m"(B), "m"(C), "m"(alphai_p), "m"(beta_p){prefetching_decl} : {{clobbered}});
+    : : "m"(A), "m"(B), "m"(C), "m"(alpha_p), "m"(beta_p){prefetching_decl} : {{clobbered}});
 
     #ifndef NDEBUG
     #ifdef _OPENMP

--- a/pspamm/codegen/architectures/hsw/generator.py
+++ b/pspamm/codegen/architectures/hsw/generator.py
@@ -10,14 +10,18 @@ from pspamm.codegen.precision import *
 class Generator(AbstractGenerator):
     template = """
 void {{funcName}} (const {{real_type}}* A, const {{real_type}}* B, {{real_type}}* C, {{real_type}} alpha, {{real_type}} beta, {{real_type}} const* prefetch) {{{{
+  {{real_type}}* alpha_p = &alpha;
+  {{real_type}}* beta_p = &beta;
   __asm__ __volatile__(
     "movq %0, %%rdi\\n\\t"
     "movq %1, %%rsi\\n\\t"
     "movq %2, %%rdx\\n\\t"
+    "movq %3, %%rbx\\n\\t"
+    "movq %4, %%rcx\\n\\t"
 {prefetching_mov}
 {{body_text}}
 
-    : : "m"(A), "m"(B), "m"(C), "m"(alpha), "m"(beta){prefetching_decl} : {{clobbered}});
+    : : "m"(A), "m"(B), "m"(C), "m"(alphai_p), "m"(beta_p){prefetching_decl} : {{clobbered}});
 
     #ifndef NDEBUG
     #ifdef _OPENMP

--- a/pspamm/codegen/architectures/hsw/generator.py
+++ b/pspamm/codegen/architectures/hsw/generator.py
@@ -57,7 +57,7 @@ void {{funcName}} (const {{real_type}}* A, const {{real_type}}* B, {{real_type}}
                                                      for r in range(vm)])
         starting_regs = [rdi, rsi, rdx]
 
-        b_reg = vm*bk 
+        b_reg = vm*bk
         alpha_reg = [xmm(b_reg), ymm(b_reg)]
         beta_reg = [xmm(b_reg + 1), ymm(b_reg + 1)]
 
@@ -85,10 +85,10 @@ void {{funcName}} (const {{real_type}}* A, const {{real_type}}* B, {{real_type}}
                         beta_reg: Register,
                         ) -> Block:
 
-        asm = block("Broadcast alpha and beta so that efficient multiplication is possible")
+        asm = block("Broadcast alpha and beta when needed")
 
-        asm.add(bcst(alpha_reg[0], alpha_reg[1]))
-        asm.add(bcst(beta_reg[0], beta_reg[1]))
+#        asm.add(bcst(alpha_reg[0], alpha_reg[1]))
+#        asm.add(bcst(beta_reg[0], beta_reg[1]))
         
         return asm
 

--- a/pspamm/codegen/architectures/hsw/generator.py
+++ b/pspamm/codegen/architectures/hsw/generator.py
@@ -47,15 +47,15 @@ void {{funcName}} (const {{real_type}}* A, const {{real_type}}* B, {{real_type}}
         B_regs = Matrix([[ymm(vm*bk + bn * r + c) for c in range(bn)] for r in range(bk)])
         C_regs = Matrix([[ymm(16 - vm*bn + vm*c + r) for c in range(bn)]
                                                      for r in range(vm)])
-        print([[ymm(vm*c + r + 2).ugly for c in range(bk)] for r in range(vm)])
-        print([[ymm(vm*bk + 2 + bn * r + c).ugly for c in range(bn)] for r in range(bk)])
+        print([[ymm(vm*c + r ).ugly for c in range(bk)] for r in range(vm)])
+        print([[ymm(vm*bk + bn * r + c).ugly for c in range(bn)] for r in range(bk)])
         print([[ymm(16 - vm*bn + vm*c + r).ugly for c in range(bn)]
                                                      for r in range(vm)])
         starting_regs = [rdi, rsi, rdx]
 
-        b_reg = B_regs[0, 0].ugly[5:]
-        alpha_reg = [xmm(int(b_reg)), ymm(int(b_reg))]
-        beta_reg = [xmm(int(b_reg) + 1), ymm(int(b_reg) + 1)]
+        b_reg = vm*bk 
+        alpha_reg = [xmm(b_reg), ymm(b_reg)]
+        beta_reg = [xmm(b_reg + 1), ymm(b_reg + 1)]
 
         available_regs = [r(9),r(10),r(11),r(13),r(14),r(15),rax, rbx, rcx]
 

--- a/pspamm/codegen/architectures/hsw/inlineprinter.py
+++ b/pspamm/codegen/architectures/hsw/inlineprinter.py
@@ -65,7 +65,7 @@ class InlinePrinter(Visitor):
         b = stmt.bcast_src.ugly
         a = stmt.dest.ugly
         # check if we broadcast a general register
-        if isinstance(stmt.bcast_scr, Regsiter):
+        if isinstance(stmt.bcast_src, Register):
             # reformat bcast_src to be a memory address
             b = "0({})".format(b)
         s = "vbroadcasts{} {}, {}".format(self.precision, b, a)

--- a/pspamm/codegen/architectures/hsw/inlineprinter.py
+++ b/pspamm/codegen/architectures/hsw/inlineprinter.py
@@ -66,12 +66,8 @@ class InlinePrinter(Visitor):
         a = stmt.dest.ugly
         # check if we broadcast a general register
         if b[2] == 'r':
-            # determine if we broadcast alpha or beta
-            src = "%3" if stmt.bcast_src.ugly == "%%rbx" else "%4"
-            b = a.replace("y", "x")
-            s = "vmovq {}, {}".format(src, b)
-            comment = "Move {scalar} into xmm register".format(scalar="alpha" if src == "%3" else "beta")
-            self.addLine(s, comment)
+            # reformat bcast_src to be a memory address
+            b = "0({})".format(b)
         s = "vbroadcasts{} {}, {}".format(self.precision, b, a)
         self.addLine(s, stmt.comment)
 

--- a/pspamm/codegen/architectures/hsw/inlineprinter.py
+++ b/pspamm/codegen/architectures/hsw/inlineprinter.py
@@ -64,7 +64,15 @@ class InlinePrinter(Visitor):
     def visitBcst(self, stmt: BcstStmt):
         b = stmt.bcast_src.ugly
         a = stmt.dest.ugly
-        s = "vbroadcasts{} {}, {}".format(self.precision, b,a)
+        # check if we broadcast a general register
+        if b[2] == 'r':
+            # determine if we broadcast alpha or beta
+            src = "%3" if stmt.bcast_src.ugly == "%%rbx" else "%4"
+            b = a.replace("y", "x")
+            s = "vmovq {}, {}".format(src, b)
+            comment = "Move {scalar} into xmm register".format(scalar="alpha" if src == "%3" else "beta")
+            self.addLine(s, comment)
+        s = "vbroadcasts{} {}, {}".format(self.precision, b, a)
         self.addLine(s, stmt.comment)
 
     def visitAdd(self, stmt: AddStmt):

--- a/pspamm/codegen/architectures/hsw/inlineprinter.py
+++ b/pspamm/codegen/architectures/hsw/inlineprinter.py
@@ -65,7 +65,7 @@ class InlinePrinter(Visitor):
         b = stmt.bcast_src.ugly
         a = stmt.dest.ugly
         # check if we broadcast a general register
-        if b[2] == 'r':
+        if isinstance(stmt.bcast_scr, Regsiter):
             # reformat bcast_src to be a memory address
             b = "0({})".format(b)
         s = "vbroadcasts{} {}, {}".format(self.precision, b, a)

--- a/pspamm/codegen/architectures/hsw/operands.py
+++ b/pspamm/codegen/architectures/hsw/operands.py
@@ -46,7 +46,11 @@ rdx = Register_HSW(AsmType.i64, "rdx")
 rdi = Register_HSW(AsmType.i64, "rdi")
 rsi = Register_HSW(AsmType.i64, "rsi")
 
-r   = lambda n: Register_HSW(AsmType.i64, "r"+str(n))
+# necessary for the bcst statements in pspamm/matmul.py, there we only need a mapping for r(3) and r(4)
+gen_regs = {3: rbx,
+            4: rcx}
+
+r   = lambda n: Register_HSW(AsmType.i64, "r"+str(n)) if n > 7 else gen_regs[n]
 xmm = lambda n: Register_HSW(AsmType.f64x2, "xmm"+str(n))
 ymm = lambda n: Register_HSW(AsmType.f64x4, "ymm"+str(n))
 

--- a/pspamm/codegen/architectures/knl/inlineprinter.py
+++ b/pspamm/codegen/architectures/knl/inlineprinter.py
@@ -52,9 +52,9 @@ class InlinePrinter(Visitor):
         if stmt.bcast:
             s = "vfmadd231p{} {}%{{1to{}%}}, {}, {}".format(self.precision, b, 8 if self.precision == 'd' else 16, m, a)
         else:
-            if m[0] == '0':
+            if stmt.mult_src.typeinfo == AsmType.i64:
                 # in this case, m is a MemoryAddress_KNL that points to alpha
-                s = "vfmadd231p{} {}%{{1to{}%}}, {}, {}".format(self.precision, m, 8 if self.precision == 'd' else 16, b, a)
+                s = "vfmadd231p{} 0({})%{{1to{}%}}, {}, {}".format(self.precision, m, 8 if self.precision == 'd' else 16, b, a)
             else:
                 s = "vfmadd231p{} {}, {}, {}".format(self.precision, b,m,a)
         self.addLine(s, stmt.comment)
@@ -63,9 +63,9 @@ class InlinePrinter(Visitor):
         b = stmt.src.ugly
         m = stmt.mult_src.ugly
         a = stmt.dest.ugly
-        if m[0] == '0':
+        if stmt.mult_src.typeinfo == AsmType.i64:
             # in this case, m is a MemoryAddress_KNL that points to alpha/beta
-            s = "vmulp{} {}%{{1to{}%}}, {}, {}".format(self.precision, m, 8 if self.precision == 'd' else 16, b, a)
+            s = "vmulp{} 0({})%{{1to{}%}}, {}, {}".format(self.precision, m, 8 if self.precision == 'd' else 16, b, a)
         else:
             s = "vmulp{} {}, {}, {}".format(self.precision, b,m,a)
         self.addLine(s, stmt.comment)

--- a/pspamm/codegen/architectures/knl/inlineprinter.py
+++ b/pspamm/codegen/architectures/knl/inlineprinter.py
@@ -53,7 +53,7 @@ class InlinePrinter(Visitor):
             s = "vfmadd231p{} {}%{{1to{}%}}, {}, {}".format(self.precision, b, 8 if self.precision == 'd' else 16, m, a)
         else:
             if stmt.mult_src.typeinfo == AsmType.i64:
-                # in this case, m is a MemoryAddress_KNL that points to alpha
+                # in this case, m is a Register that points to alpha; manually format to be a memory address
                 s = "vfmadd231p{} 0({})%{{1to{}%}}, {}, {}".format(self.precision, m, 8 if self.precision == 'd' else 16, b, a)
             else:
                 s = "vfmadd231p{} {}, {}, {}".format(self.precision, b,m,a)
@@ -64,7 +64,7 @@ class InlinePrinter(Visitor):
         m = stmt.mult_src.ugly
         a = stmt.dest.ugly
         if stmt.mult_src.typeinfo == AsmType.i64:
-            # in this case, m is a MemoryAddress_KNL that points to alpha/beta
+            # in this case, m is a Register that points to alpha/beta; manually format to be a memory address
             s = "vmulp{} 0({})%{{1to{}%}}, {}, {}".format(self.precision, m, 8 if self.precision == 'd' else 16, b, a)
         else:
             s = "vmulp{} {}, {}, {}".format(self.precision, b,m,a)

--- a/pspamm/codegen/architectures/knl/inlineprinter.py
+++ b/pspamm/codegen/architectures/knl/inlineprinter.py
@@ -52,14 +52,22 @@ class InlinePrinter(Visitor):
         if stmt.bcast:
             s = "vfmadd231p{} {}%{{1to{}%}}, {}, {}".format(self.precision, b, 8 if self.precision == 'd' else 16, m, a)
         else:
-            s = "vfmadd231p{} {}, {}, {}".format(self.precision, b,m,a)
+            if m[0] == '0':
+                # in this case, m is a MemoryAddress_KNL that points to alpha
+                s = "vfmadd231p{} {}%{{1to{}%}}, {}, {}".format(self.precision, m, 8 if self.precision == 'd' else 16, b, a)
+            else:
+                s = "vfmadd231p{} {}, {}, {}".format(self.precision, b,m,a)
         self.addLine(s, stmt.comment)
 
     def visitMul(self, stmt: MulStmt):
         b = stmt.src.ugly
         m = stmt.mult_src.ugly
         a = stmt.dest.ugly
-        s = "vmulp{} {}, {}, {}".format(self.precision, b,m,a)
+        if m[0] == '0':
+            # in this case, m is a MemoryAddress_KNL that points to alpha/beta
+            s = "vmulp{} {}%{{1to{}%}}, {}, {}".format(self.precision, m, 8 if self.precision == 'd' else 16, b, a)
+        else:
+            s = "vmulp{} {}, {}, {}".format(self.precision, b,m,a)
         self.addLine(s, stmt.comment)
 
     def visitBcst(self, stmt: BcstStmt):

--- a/pspamm/codegen/architectures/knl/operands.py
+++ b/pspamm/codegen/architectures/knl/operands.py
@@ -39,21 +39,6 @@ class Register_KNL(Register):
         return "%%" + self.value
 
 
-rax = Register_KNL(AsmType.i64, "rax")
-rbx = Register_KNL(AsmType.i64, "rbx")
-rcx = Register_KNL(AsmType.i64, "rcx")
-rdx = Register_KNL(AsmType.i64, "rdx")
-rdi = Register_KNL(AsmType.i64, "rdi")
-rsi = Register_KNL(AsmType.i64, "rsi")
-
-r   = lambda n: Register_KNL(AsmType.i64, "r"+str(n))
-xmm = lambda n: Register_KNL(AsmType.f64x2, "xmm"+str(n))
-ymm = lambda n: Register_KNL(AsmType.f64x4, "ymm"+str(n))
-zmm = lambda n: Register_KNL(AsmType.f64x8, "zmm"+str(n))
-
-
-
-
 class MemoryAddress_KNL(MemoryAddress):
     
     def __init__(self,
@@ -72,11 +57,27 @@ class MemoryAddress_KNL(MemoryAddress):
             return "{}({})".format(self.disp,self.base.ugly)
         return "{}({},{},{})".format(self.disp,self.base.ugly,self.index.ugly,self.scaling)
 
+    @property
+    def clobbered(self):
+        return self.base.clobbered
+
 def mem(base, offset, index=None, scaling=None):
     return MemoryAddress_KNL(base, offset, index, scaling)
 
 
+rax = Register_KNL(AsmType.i64, "rax")
+rbx = Register_KNL(AsmType.i64, "rbx")
+rcx = Register_KNL(AsmType.i64, "rcx")
+rdx = Register_KNL(AsmType.i64, "rdx")
+rdi = Register_KNL(AsmType.i64, "rdi")
+rsi = Register_KNL(AsmType.i64, "rsi")
 
+# necessary for the inline broadcasting in vfmadd231p{d/s} and vmulp{d/s}, we only need a mapping for r(3) and r(4)
+gen_regs = {3: mem(rbx, 0),
+            4: mem(rcx, 0)}
 
-
+r   = lambda n: Register_KNL(AsmType.i64, "r"+str(n)) if n > 7 else gen_regs[n]
+xmm = lambda n: Register_KNL(AsmType.f64x2, "xmm"+str(n))
+ymm = lambda n: Register_KNL(AsmType.f64x4, "ymm"+str(n))
+zmm = lambda n: Register_KNL(AsmType.f64x8, "zmm"+str(n))
 

--- a/pspamm/codegen/architectures/knl/operands.py
+++ b/pspamm/codegen/architectures/knl/operands.py
@@ -73,8 +73,8 @@ rdi = Register_KNL(AsmType.i64, "rdi")
 rsi = Register_KNL(AsmType.i64, "rsi")
 
 # necessary for the inline broadcasting in vfmadd231p{d/s} and vmulp{d/s}, we only need a mapping for r(3) and r(4)
-gen_regs = {3: mem(rbx, 0),
-            4: mem(rcx, 0)}
+gen_regs = {3: rbx,
+            4: rcx}
 
 r   = lambda n: Register_KNL(AsmType.i64, "r"+str(n)) if n > 7 else gen_regs[n]
 xmm = lambda n: Register_KNL(AsmType.f64x2, "xmm"+str(n))

--- a/pspamm/scripts/max_arm.py
+++ b/pspamm/scripts/max_arm.py
@@ -16,7 +16,7 @@ def getBlocksize(m , n, bk):
 
 
 def ARM_condition(bm, bn, bk):
-  v_size = -2
+  v_size = 2
   # ceiling division
   vm = -(bm // -v_size)
   return (bn+bk) * vm + bn <= 32

--- a/pspamm/scripts/max_arm.py
+++ b/pspamm/scripts/max_arm.py
@@ -16,4 +16,4 @@ def getBlocksize(m , n, bk):
 
 
 def ARM_condition(bm, bn, bk):
-    return (bn+bk) * (bm / 2) + bn + 2 <= 32
+    return (bn+bk) * (bm / 2) + bn <= 32

--- a/pspamm/scripts/max_arm.py
+++ b/pspamm/scripts/max_arm.py
@@ -16,4 +16,7 @@ def getBlocksize(m , n, bk):
 
 
 def ARM_condition(bm, bn, bk):
-    return (bn+bk) * (bm / 2) + bn <= 32
+  v_size = -2
+  # ceiling division
+  vm = -(bm // -v_size)
+  return (bn+bk) * vm + bn <= 32

--- a/pspamm/scripts/max_arm_sve.py
+++ b/pspamm/scripts/max_arm_sve.py
@@ -22,7 +22,9 @@ def getBlocksize(m, n, bk, v_size=2):
 
 
 def ARM_condition(bm, bn, bk, v_size):
-    return (bn + bk) * (bm / v_size) + bn + 2 <= 32
+    # ceiling division
+    vm = -(bm // -v_size)  
+    return (bn + bk) * vm + bn <= 32
 
 
 def tileable(m, bm):

--- a/pspamm/scripts/max_bn_hsw.py
+++ b/pspamm/scripts/max_bn_hsw.py
@@ -11,4 +11,6 @@ def getBlocksize(m, n, bk, v_size=4):
 
 
 def HSW_condition(bm, bn, bk, v_size):
-    return (bn + bk) * (bm / v_size) + bn * bk <= 16
+	# ceiling division
+	vm = -(bm // -v_size)
+	return (bn + bk) * vm + bn * bk <= 16

--- a/pspamm/scripts/max_bn_hsw.py
+++ b/pspamm/scripts/max_bn_hsw.py
@@ -11,4 +11,4 @@ def getBlocksize(m, n, bk, v_size=4):
 
 
 def HSW_condition(bm, bn, bk, v_size):
-    return (bn + bk) * (bm / v_size) + bn * bk + 2 <= 16
+    return (bn + bk) * (bm / v_size) + bn * bk <= 16

--- a/pspamm/scripts/max_bn_knl.py
+++ b/pspamm/scripts/max_bn_knl.py
@@ -11,4 +11,6 @@ def getBlocksize(m, n, bk, v_size=8):
 
 
 def KNL_condition(bm, bn, bk, v_size):
-    return (bn+bk) * (bm / v_size) <= 32
+    # ceiling division
+    vm = -(bm // -v_size)
+    return (bn+bk) * vm <= 32

--- a/pspamm/scripts/max_bn_knl.py
+++ b/pspamm/scripts/max_bn_knl.py
@@ -11,4 +11,4 @@ def getBlocksize(m, n, bk, v_size=8):
 
 
 def KNL_condition(bm, bn, bk, v_size):
-    return (bn+bk) * (bm / v_size) + 2 <= 32
+    return (bn+bk) * (bm / v_size) <= 32

--- a/pspamm/scripts/max_hsw.py
+++ b/pspamm/scripts/max_hsw.py
@@ -17,4 +17,6 @@ def getBlocksize(m , n, bk):
 
 def HSW_condition(bm, bn, bk):
 	v_size = 4
-	return (bn + bk) * (bm / v_size) + bn * bk <= 16
+	# ceiling division
+	vm = -(bm // -v_size)
+	return (bn + bk) * vm + bn * bk <= 16

--- a/pspamm/scripts/max_hsw.py
+++ b/pspamm/scripts/max_hsw.py
@@ -17,4 +17,4 @@ def getBlocksize(m , n, bk):
 
 def HSW_condition(bm, bn, bk):
 	v_size = 4
-	return (bn + bk) * (bm / v_size) + bn * bk + 2 <= 16
+	return (bn + bk) * (bm / v_size) + bn * bk <= 16

--- a/pspamm/scripts/max_knl.py
+++ b/pspamm/scripts/max_knl.py
@@ -16,4 +16,7 @@ def getBlocksize(m , n, bk):
 
 
 def KNL_condition(bm, bn, bk):
-    return (bn+bk) * (bm / 8) <= 32
+    v_size = 8
+    # ceiling division
+    vm = -(bm // -v_size)
+    return (bn+bk) * vm <= 32

--- a/pspamm/scripts/max_knl.py
+++ b/pspamm/scripts/max_knl.py
@@ -16,4 +16,4 @@ def getBlocksize(m , n, bk):
 
 
 def KNL_condition(bm, bn, bk):
-    return (bn+bk) * (bm / 8) + 2 <= 32
+    return (bn+bk) * (bm / 8) <= 32

--- a/pspamm/scripts/old_arm.py
+++ b/pspamm/scripts/old_arm.py
@@ -26,4 +26,6 @@ def lowerToNextDiv(m, n, bm, bn, v_size):
 
 
 def ARM_condition(bm, bn, bk, v_size):
-	return (bn+bk) * (bm / v_size) + bn + 2 <= 32
+  # ceiling division
+  vm = -(bm // -v_size)
+  return (bn+bk) * vm + bn <= 32

--- a/pspamm/scripts/old_hsw.py
+++ b/pspamm/scripts/old_hsw.py
@@ -27,4 +27,4 @@ def lowerToNextDiv(m, n, bm, bn):
 
 def HSW_condition(bm, bn, bk):
 	v_size = 4
-	return (bn + bk) * (bm / v_size) + bn * bk + 2 <= 16
+	return (bn + bk) * (bm / v_size) + bn * bk <= 16

--- a/pspamm/scripts/old_hsw.py
+++ b/pspamm/scripts/old_hsw.py
@@ -27,4 +27,6 @@ def lowerToNextDiv(m, n, bm, bn):
 
 def HSW_condition(bm, bn, bk):
 	v_size = 4
-	return (bn + bk) * (bm / v_size) + bn * bk <= 16
+	# ceiling division
+	vm = -(bm // -v_size)
+	return (bn + bk) * vm + bn * bk <= 16

--- a/pspamm/scripts/old_knl.py
+++ b/pspamm/scripts/old_knl.py
@@ -26,4 +26,7 @@ def lowerToNextDiv(m, n, bm, bn):
 
 
 def KNL_condition(bm, bn, bk):
-	return (bn+bk) * (bm / 8)  <= 32
+	v_size = 8
+	# ceiling division
+	vm = -(bm // -v_size)
+	return (bn+bk) * vm  <= 32

--- a/pspamm/scripts/old_knl.py
+++ b/pspamm/scripts/old_knl.py
@@ -26,4 +26,4 @@ def lowerToNextDiv(m, n, bm, bn):
 
 
 def KNL_condition(bm, bn, bk):
-	return (bn+bk) * (bm / 8) + 2 <= 32
+	return (bn+bk) * (bm / 8)  <= 32

--- a/tests/unit_tests_arm_sve.py
+++ b/tests/unit_tests_arm_sve.py
@@ -25,7 +25,7 @@ delta_dp = 1e-7 # epsilon is around e-15 => /2
 # test cases for double precision multiplication
 kernels.append(generator.DenseKernel("sve_mixed_test1", 9, 9, 9, 9, 9, 9, 1.0, 0.0, [(3, 3)] + [x.getBlocksize(9, 9, 1, v_size) for x in blocksize_algs], delta_dp))
 kernels.append(generator.SparseKernel("sve_mixed_test2", 9, 9, 9, 9, 0, 9, 4.0, 2.5, [(3, 3)] + [x.getBlocksize(9, 9, 1, v_size) for x in blocksize_algs], generator.generateMTX(9, 9, 20), delta_dp))
-kernels.append(generator.SparseKernel("sve_mixed_test3", 18, 18, 18, 18, 0, 18, 3.4, -2.5, [(1, 1), (3, 3), (6, 6), (9, 9)] + [x.getBlocksize(18, 18, 1, v_size) for x in blocksize_algs], generator.generateMTX(18, 18, 59), delta_dp))
+kernels.append(generator.SparseKernel("sve_mixed_test3", 18, 18, 18, 18, 0, 18, 3.4, -2.5, [(1, 1), (3, 3), (6, 6)] + [x.getBlocksize(18, 18, 1, v_size) for x in blocksize_algs], generator.generateMTX(18, 18, 59), delta_dp))
 kernels.append(generator.SparseKernel("sve_mixed_test4", 80, 80, 80, 80, 0, 80, 0.0, -2.5, [(4, 4), (8, 8)] + [x.getBlocksize(80, 80, 1, v_size) for x in blocksize_algs], generator.generateMTX(80, 80, 312), delta_dp))
 kernels.append(generator.SparseKernel("sve_mixed_test5", 8, 8, 8, 10, 0, 8, 3.0, -0.9, [(2, 2), (4, 4)] + [x.getBlocksize(8, 8, 1, v_size) for x in blocksize_algs], generator.generateMTX(8, 8, 6), delta_dp))
 kernels.append(generator.DenseKernel("sve_mixed_test6", 8, 8, 8, 10, 8, 8, 3.0, -0.9, [(2, 2), (4, 4)] + [x.getBlocksize(8, 8, 1, v_size) for x in blocksize_algs], delta_dp))


### PR DESCRIPTION
This PR adds explicit broadcasting of the alpha and beta values where necessary to make the first two statically defined vector registers available to store matrix elements when possible. This affects the generators for the `hsw`, `arm`, and `arm_sve` architectures .
For the `knl` generator, we can use implicit broadcasting in the `mul` and `fmla` instructions while skipping the broadcast instruction completely. 

In order to keep the naming convention of the general registers that are used consistent, I added a partial mapping of `r(n)` to `rax`, `rbx`, etc. registers to `hsw/operands.py` and `knl/operands.py`. I ended up only defining `r(3) = rbx` and `r(4) = rcx` as a quick mapping, because mapping e.g. `rdi` to another input value for `r(n)` should not be allowed since `rdi` is used to store a memory address in the `hsw` and `knl` generator.