### PR TITLE
Fix Register Clobbering

### DIFF
--- a/pspamm/codegen/architectures/arm/generator.py
+++ b/pspamm/codegen/architectures/arm/generator.py
@@ -55,7 +55,7 @@ void {funcName} (const {real_type}* A, const {real_type}* B, {real_type}* C, {re
         beta_reg = [v(b_reg + 1), v(b_reg + 1)]
 
 
-        starting_regs = [r(0), r(1), r(2)]
+        starting_regs = [r(0), r(1), r(2), r(3), r(4)]
 
         additional_regs = [r(11), xzr]
 

--- a/pspamm/codegen/architectures/arm_sve/generator.py
+++ b/pspamm/codegen/architectures/arm_sve/generator.py
@@ -89,7 +89,7 @@ void {funcName} (const {real_type}* A, const {real_type}* B, {real_type}* C, con
         alpha_reg = [z(b_reg, prec), z(b_reg, prec)]
         beta_reg = [z(b_reg + 1, prec), z(b_reg + 1, prec)]
 
-        starting_regs = [r(0), r(1), r(2), r(3), r(4), r(6)]  # r6 is needed for predicate creation, r5 is added in init_prefetching()
+        starting_regs = [r(0), r(1), r(2), r(3), r(4), r(5), r(6)]  # r6 is needed for predicate creation, r5 is added in init_prefetching()
 
         additional_regs = [r(11), l("0.0"), r(10), r(8)]  # r10 used for scaling offsets
 

--- a/pspamm/codegen/architectures/hsw/generator.py
+++ b/pspamm/codegen/architectures/hsw/generator.py
@@ -55,13 +55,13 @@ void {{funcName}} (const {{real_type}}* A, const {{real_type}}* B, {{real_type}}
         print([[ymm(vm*bk + bn * r + c).ugly for c in range(bn)] for r in range(bk)])
         print([[ymm(16 - vm*bn + vm*c + r).ugly for c in range(bn)]
                                                      for r in range(vm)])
-        starting_regs = [rdi, rsi, rdx]
+        starting_regs = [rdi, rsi, rdx, rbx, rcx]
 
         b_reg = vm*bk
         alpha_reg = [xmm(b_reg), ymm(b_reg)]
         beta_reg = [xmm(b_reg + 1), ymm(b_reg + 1)]
 
-        available_regs = [r(9),r(10),r(11),r(13),r(14),r(15),rax, rbx, rcx]
+        available_regs = [r(9),r(10),r(11),r(13),r(14),r(15),rax]
 
         additional_regs = [r(8)]
 

--- a/pspamm/codegen/architectures/hsw/operands.py
+++ b/pspamm/codegen/architectures/hsw/operands.py
@@ -46,10 +46,6 @@ rdx = Register_HSW(AsmType.i64, "rdx")
 rdi = Register_HSW(AsmType.i64, "rdi")
 rsi = Register_HSW(AsmType.i64, "rsi")
 
-# necessary for the bcst statements in pspamm/matmul.py, there we only need a mapping for r(3) and r(4)
-gen_regs = {3: rbx,
-            4: rcx}
-
 r   = lambda n: Register_HSW(AsmType.i64, "r"+str(n)) if n > 7 else gen_regs[n]
 xmm = lambda n: Register_HSW(AsmType.f64x2, "xmm"+str(n))
 ymm = lambda n: Register_HSW(AsmType.f64x4, "ymm"+str(n))

--- a/pspamm/codegen/architectures/knl/generator.py
+++ b/pspamm/codegen/architectures/knl/generator.py
@@ -52,12 +52,12 @@ void {{funcName}} (const {{real_type}}* A, const {{real_type}}* B, {{real_type}}
         C_regs = Matrix([[zmm(32 - vm*bn + vm*c + r) for c in range(bn)]
                                                      for r in range(vm)])
 
-        starting_regs = [rdi, rsi, rdx]
+        starting_regs = [rdi, rsi, rdx, rbx, rcx]
 
-        alpha_reg = [r(3), r(3)]
-        beta_reg = [r(4), r(4)]
+        alpha_reg = [rbx, rbx]
+        beta_reg = [rcx, rcx]
 
-        available_regs = [r(9),r(10),r(11),r(13),r(14),r(15),rax, rbx, rcx]
+        available_regs = [r(9),r(10),r(11),r(13),r(14),r(15),rax]
 
         additional_regs = [r(8)]
 

--- a/pspamm/codegen/architectures/knl/operands.py
+++ b/pspamm/codegen/architectures/knl/operands.py
@@ -72,10 +72,6 @@ rdx = Register_KNL(AsmType.i64, "rdx")
 rdi = Register_KNL(AsmType.i64, "rdi")
 rsi = Register_KNL(AsmType.i64, "rsi")
 
-# necessary for the inline broadcasting in vfmadd231p{d/s} and vmulp{d/s}, we only need a mapping for r(3) and r(4)
-gen_regs = {3: rbx,
-            4: rcx}
-
 r   = lambda n: Register_KNL(AsmType.i64, "r"+str(n)) if n > 7 else gen_regs[n]
 xmm = lambda n: Register_KNL(AsmType.f64x2, "xmm"+str(n))
 ymm = lambda n: Register_KNL(AsmType.f64x4, "ymm"+str(n))

--- a/pspamm/matmul.py
+++ b/pspamm/matmul.py
@@ -196,7 +196,8 @@ class MatMul:
 
         self.A_regs, self.B_regs, self.C_regs, self.starting_regs, self.alpha_reg, self.beta_reg, self.loop_reg, self.additional_regs = self.generator.make_reg_blocks(self.bm, self.bn, self.bk, self.v_size, self.nnz, self.m, self.n, self.k)
 
-        self.alpha_bcst_reg, self.beta_bcst_reg = pspamm.architecture.operands.r(3), pspamm.architecture.operands.r(4)
+        self.alpha_bcst_reg, self.beta_bcst_reg = self.starting_regs[3], self.starting_regs[4]
+
 
         self.A = DenseCursor("A", self.starting_regs[0], self.m, self.k, self.lda, self.bm, self.bk, self.precision.value)
         self.B = BlockCursor("B", self.starting_regs[1], self.k, self.n, self.ldb, self.bk, self.bn, self.precision.value, blocks, patterns,mtx_overhead)


### PR DESCRIPTION
Haswell (and probably also knl/skx) hadn't had `rbx` and `rcx` clobbered, and hence failed sometimes due to that. Thus, we now add the registers to the `starting_regs` instead.